### PR TITLE
chore: harden multi-agent collaboration workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,13 @@
+# Default owner
 * @sdevisch
+
+# Path lanes to reduce review overlap between parallel agents.
+/src/ @sdevisch
+/tests/ @sdevisch
+/scripts/ @sdevisch
+/config/ @sdevisch
+/docs/ @sdevisch
+
+# Lock down collaboration and CI policy files.
+/.github/CODEOWNERS @sdevisch
+/.github/workflows/ @sdevisch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   version-policy:

--- a/docs/AGENT_COLLABORATION.md
+++ b/docs/AGENT_COLLABORATION.md
@@ -1,0 +1,53 @@
+# Agent Collaboration Contract
+
+## Goals
+
+- Enable multiple agents to work in parallel without stepping on each other.
+- Keep integration quality high with serialized merges into protected branches.
+
+## Required workflow
+
+1. Start from an isolated lane (worktree or clone) with a dedicated branch.
+2. Claim the path scope before editing (`.agent-coordination` claim).
+3. Keep changes inside claimed scope when possible.
+4. Open a PR and wait for required CI checks.
+5. Merge through merge queue when targeting protected branches.
+6. Release the claim after merge or task cancellation.
+
+## Lane bootstrap examples
+
+```bash
+/Users/sdevisch/dev/tools/agent-collab/agentctl.sh bootstrap \
+  --repo <repo-path> \
+  --agent <agent-name> \
+  --task <task-slug> \
+  --mode worktree \
+  --sparse ".github,docs,src,tests"
+```
+
+## Path claim examples
+
+```bash
+/Users/sdevisch/dev/tools/agent-collab/agentctl.sh claim \
+  --repo <repo-path> \
+  --agent <agent-name> \
+  --path <repo-relative-path> \
+  --ttl-hours 8 \
+  --note "short task description"
+
+/Users/sdevisch/dev/tools/agent-collab/agentctl.sh release --id <claim-id>
+```
+
+## CI and protection requirements
+
+- Workflows that gate protected branches must run on `pull_request` and `merge_group`.
+- Workflow-level `concurrency` must be enabled to prevent duplicate CI storms.
+- `CODEOWNERS` must include ownership for policy files:
+  - `.github/CODEOWNERS`
+  - `.github/workflows/`
+
+## Review policy
+
+- Avoid multi-domain PRs when not needed.
+- Keep PR titles scoped to one lane/path ownership.
+- If two tasks require overlapping paths, sequence them explicitly instead of parallelizing.


### PR DESCRIPTION
## Summary\n- add merge-queue compatible trigger (merge_group) and workflow concurrency to CI\n- strengthen CODEOWNERS with path lanes and policy-file ownership\n- add docs/AGENT_COLLABORATION.md with lane/claim workflow\n\n## Notes\n- changes were developed in isolated worktree lane to avoid touching active local branches\n- merge queue rule update via ruleset API is currently rejected as unsupported for this repo plan/API capability