### PR TITLE
W3-A: unified router-check command and provider matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ROOT := $(CURDIR)
 export PYTHONPATH := $(ROOT)/src:$(PYTHONPATH)
 AUTONOMY := $(PYTHON) -m orxaq_autonomy.cli --root $(ROOT)
 
-.PHONY: run supervise start stop ensure status health logs reset preflight workspace open-vscode open-cursor open-pycharm install-keepalive uninstall-keepalive keepalive-status lint test version-check repo-hygiene bump-patch bump-minor bump-major package setup pre-commit pre-push
+.PHONY: run supervise start stop ensure status health logs reset preflight workspace open-vscode open-cursor open-pycharm install-keepalive uninstall-keepalive keepalive-status router-check lint test version-check repo-hygiene bump-patch bump-minor bump-major package setup pre-commit pre-push
 
 run:
 	$(AUTONOMY) run
@@ -55,6 +55,9 @@ uninstall-keepalive:
 
 keepalive-status:
 	$(AUTONOMY) keepalive-status
+
+router-check:
+	$(AUTONOMY) router-check --config ./config/router.example.yaml --output ./artifacts/router_check.json --strict
 
 setup:
 	$(PYTHON) -m pip install -e .

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ make status
 make health
 make logs
 make stop
+make router-check
 make install-keepalive
 make keepalive-status
 make workspace
@@ -111,15 +112,18 @@ make supervise
 Budget and routing controls:
 
 - routing policy file: `config/routing_policy.yaml`
+- router config example: `config/router.example.yaml`
 - runtime budget telemetry: `artifacts/autonomy/budget.json`
 - health snapshot includes latest `budget` section (`make health`)
 - stop report: `artifacts/autonomy/AUTONOMY_STOP_REPORT.md`
+- router connectivity report: `artifacts/router_check.json`
 
 Stop with report + optional issue filing:
 
 ```bash
 python3 -m orxaq_autonomy.cli --root . stop --reason "blocked by failing CI"
 python3 -m orxaq_autonomy.cli --root . stop --reason "manual intervention" --file-issue --issue-repo Orxaq/orxaq-ops --issue-label autonomy --issue-label blocked
+python3 -m orxaq_autonomy.cli --root . router-check --config ./config/router.example.yaml --lane L0 --output ./artifacts/router_check.json --strict
 ```
 
 ## Reuse Model

--- a/config/router.example.yaml
+++ b/config/router.example.yaml
@@ -1,0 +1,53 @@
+schema_version: llm-router.v1
+
+router:
+  strategy: first_healthy
+  timeout_sec: 5
+  fallback_order: [L0, L1, L2, L3]
+
+lanes:
+  L0: [lmstudio-local]
+  L1: [openai-small, gemini-small, claude-small]
+  L2: [openai-standard, gemini-standard, claude-standard]
+  L3: [openai-audit]
+
+providers:
+  - name: lmstudio-local
+    kind: openai_compat
+    base_url: http://127.0.0.1:1234/v1
+    required: false
+
+  - name: openai-small
+    kind: openai_compat
+    base_url: https://api.openai.com/v1
+    required: false
+
+  - name: gemini-small
+    kind: openai_compat
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai
+    required: false
+
+  - name: claude-small
+    kind: openai_compat
+    base_url: https://api.anthropic.com/v1
+    required: false
+
+  - name: openai-standard
+    kind: openai_compat
+    base_url: https://api.openai.com/v1
+    required: false
+
+  - name: gemini-standard
+    kind: openai_compat
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai
+    required: false
+
+  - name: claude-standard
+    kind: openai_compat
+    base_url: https://api.anthropic.com/v1
+    required: false
+
+  - name: openai-audit
+    kind: openai_compat
+    base_url: https://api.openai.com/v1
+    required: false

--- a/docs/ROUTER.md
+++ b/docs/ROUTER.md
@@ -1,0 +1,32 @@
+# Unified LLM Router (W3-A)
+
+## Goal
+
+Provide one OpenAI-compatible interface for multi-provider routing with lane-based fallback.
+
+## Config
+
+- Example config: `config/router.example.yaml`
+- Check command:
+  - `python3 -m orxaq_autonomy.cli --root . router-check --config ./config/router.example.yaml --output ./artifacts/router_check.json --strict`
+
+## Routing Model
+
+- `L0`: local LM Studio-first for cheapest tasks.
+- `L1`: low-cost remote providers.
+- `L2`: stronger remote providers for complex tasks.
+- `L3`: audit-grade provider for safety/release decisions.
+
+## Health and Fallback
+
+- `router-check` probes each selected provider using `GET /v1/models`.
+- Report: `artifacts/router_check.json`
+- Required providers drive strict pass/fail (`required_down == 0`).
+- Fallback order comes from `router.fallback_order`.
+
+## Orxaq Integration
+
+`orxaq` live LLM calls support router-mode via env vars:
+
+- `ORXAQ_LLM_ROUTER_BASE_URL` (e.g. `http://127.0.0.1:4000/v1`)
+- `ORXAQ_LLM_PROVIDER` (trace label, e.g. `router`, `openai`, `gemini`, `claude`)

--- a/src/orxaq_autonomy/router.py
+++ b/src/orxaq_autonomy/router.py
@@ -1,0 +1,243 @@
+"""Provider router checks for OpenAI-compatible multi-provider gateways."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib import error as urllib_error
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
+
+
+@dataclass(frozen=True)
+class RouterProvider:
+    name: str
+    kind: str
+    base_url: str
+    required: bool
+
+
+@dataclass(frozen=True)
+class RouterProviderStatus:
+    name: str
+    kind: str
+    base_url: str
+    checked_url: str
+    required: bool
+    status: str
+    latency_ms: float | None
+    error: str
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["ok"] = self.status == "up"
+        return payload
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_structured_payload(raw_text: str) -> Any:
+    try:
+        return json.loads(raw_text)
+    except Exception:
+        try:
+            import yaml  # type: ignore
+        except Exception as err:  # noqa: BLE001
+            raise ValueError("router config must be JSON or YAML (requires PyYAML)") from err
+        return yaml.safe_load(raw_text)
+
+
+def _read_router_config(config_path: str) -> dict[str, Any]:
+    raw = Path(config_path).expanduser().read_text(encoding="utf-8")
+    payload = _load_structured_payload(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("router config root must be an object")
+    return payload
+
+
+def _extract_providers(payload: dict[str, Any]) -> list[RouterProvider]:
+    rows = payload.get("providers", [])
+    if not isinstance(rows, list):
+        raise ValueError("router config must define providers[]")
+    providers: list[RouterProvider] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name", "")).strip()
+        kind = str(row.get("kind", "openai_compat")).strip().lower()
+        base_url = str(row.get("base_url", "")).strip()
+        required = bool(row.get("required", False))
+        if not name or not base_url:
+            continue
+        providers.append(RouterProvider(name=name, kind=kind, base_url=base_url, required=required))
+    return providers
+
+
+def _resolve_lane_providers(payload: dict[str, Any], lane: str | None) -> list[str]:
+    lanes = payload.get("lanes", {})
+    if not isinstance(lanes, dict):
+        return []
+    if lane:
+        values = lanes.get(lane, [])
+        return [str(item).strip() for item in values if str(item).strip()] if isinstance(values, list) else []
+    router_cfg = payload.get("router", {})
+    fallback = []
+    if isinstance(router_cfg, dict):
+        fallback_raw = router_cfg.get("fallback_order", [])
+        if isinstance(fallback_raw, list):
+            fallback = [str(item).strip() for item in fallback_raw if str(item).strip()]
+    order = fallback or [str(name).strip() for name in lanes.keys()]
+    names: list[str] = []
+    for lane_name in order:
+        values = lanes.get(lane_name, [])
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            name = str(item).strip()
+            if name and name not in names:
+                names.append(name)
+    return names
+
+
+def _models_url(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    if base.endswith("/models"):
+        return base
+    return f"{base}/models"
+
+
+def _check_provider(provider: RouterProvider, timeout_sec: int) -> RouterProviderStatus:
+    checked_url = _models_url(provider.base_url)
+    parsed = urllib_parse.urlparse(checked_url)
+    if parsed.scheme not in {"http", "https"}:
+        return RouterProviderStatus(
+            name=provider.name,
+            kind=provider.kind,
+            base_url=provider.base_url,
+            checked_url=checked_url,
+            required=provider.required,
+            status="down" if provider.required else "skipped",
+            latency_ms=None,
+            error="unsupported URL scheme",
+        )
+    request = urllib_request.Request(
+        checked_url,
+        method="GET",
+        headers={"User-Agent": "orxaq-autonomy/router-check"},
+    )
+    started = time.monotonic()
+    try:
+        with urllib_request.urlopen(request, timeout=max(1, int(timeout_sec))) as response:  # nosec B310
+            status_code = int(getattr(response, "status", 200))
+            body = response.read().decode("utf-8", errors="replace")
+        latency_ms = round((time.monotonic() - started) * 1000.0, 3)
+        if status_code >= 400:
+            raise RuntimeError(f"HTTP {status_code}")
+        payload = json.loads(body)
+        if isinstance(payload, dict):
+            if not isinstance(payload.get("data", []), list) and not isinstance(payload.get("models", []), list):
+                raise ValueError("models list missing in response")
+        return RouterProviderStatus(
+            name=provider.name,
+            kind=provider.kind,
+            base_url=provider.base_url,
+            checked_url=checked_url,
+            required=provider.required,
+            status="up",
+            latency_ms=latency_ms,
+            error="",
+        )
+    except urllib_error.HTTPError as err:
+        latency_ms = round((time.monotonic() - started) * 1000.0, 3)
+        return RouterProviderStatus(
+            name=provider.name,
+            kind=provider.kind,
+            base_url=provider.base_url,
+            checked_url=checked_url,
+            required=provider.required,
+            status="down" if provider.required else "skipped",
+            latency_ms=latency_ms,
+            error=f"HTTP {err.code}",
+        )
+    except urllib_error.URLError as err:
+        return RouterProviderStatus(
+            name=provider.name,
+            kind=provider.kind,
+            base_url=provider.base_url,
+            checked_url=checked_url,
+            required=provider.required,
+            status="down" if provider.required else "skipped",
+            latency_ms=None,
+            error=str(err.reason)[:300],
+        )
+    except Exception as err:  # noqa: BLE001
+        return RouterProviderStatus(
+            name=provider.name,
+            kind=provider.kind,
+            base_url=provider.base_url,
+            checked_url=checked_url,
+            required=provider.required,
+            status="down" if provider.required else "skipped",
+            latency_ms=None,
+            error=str(err)[:300],
+        )
+
+
+def run_router_check(
+    *,
+    root: str = ".",
+    config_path: str = "./config/router.example.yaml",
+    output_path: str = "./artifacts/router_check.json",
+    lane: str = "",
+    timeout_sec: int = 5,
+) -> dict[str, Any]:
+    root_path = Path(root).expanduser().resolve()
+    config_file = Path(config_path).expanduser()
+    if not config_file.is_absolute():
+        config_file = (root_path / config_file).resolve()
+    output_file = Path(output_path).expanduser()
+    if not output_file.is_absolute():
+        output_file = (root_path / output_file).resolve()
+
+    payload = _read_router_config(str(config_file))
+    providers = _extract_providers(payload)
+    selected_names = _resolve_lane_providers(payload, lane.strip() or None)
+    selected_name_set = set(selected_names)
+
+    selected = [row for row in providers if row.name in selected_name_set] if selected_name_set else providers
+    statuses = [_check_provider(row, timeout_sec=max(1, int(timeout_sec))) for row in selected]
+
+    required_total = sum(1 for row in statuses if row.required)
+    required_down = sum(1 for row in statuses if row.required and row.status != "up")
+    up_total = sum(1 for row in statuses if row.status == "up")
+    down_total = sum(1 for row in statuses if row.status == "down")
+    skipped_total = sum(1 for row in statuses if row.status == "skipped")
+
+    report = {
+        "schema_version": "router-check.v1",
+        "timestamp": _utc_now_iso(),
+        "root": str(root_path),
+        "config_path": str(config_file),
+        "output_path": str(output_file),
+        "lane": lane.strip() or None,
+        "providers": [row.to_dict() for row in statuses],
+        "summary": {
+            "provider_total": len(statuses),
+            "provider_up": up_total,
+            "provider_down": down_total,
+            "provider_skipped": skipped_total,
+            "required_total": required_total,
+            "required_down": required_down,
+            "all_required_up": required_down == 0,
+            "overall_ok": required_down == 0,
+        },
+    }
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report

--- a/tests/test_autonomy_cli.py
+++ b/tests/test_autonomy_cli.py
@@ -75,6 +75,31 @@ class CliTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             stop.assert_called_once()
 
+    def test_router_check_command(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            self._prep_root(root)
+            with mock.patch(
+                "orxaq_autonomy.cli.run_router_check",
+                return_value={"summary": {"overall_ok": True}, "providers": []},
+            ) as check:
+                rc = cli.main(
+                    [
+                        "--root",
+                        str(root),
+                        "router-check",
+                        "--config",
+                        "./config/router.example.yaml",
+                        "--output",
+                        "./artifacts/router_check.json",
+                        "--lane",
+                        "L0",
+                        "--strict",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            check.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_autonomy_router.py
+++ b/tests/test_autonomy_router.py
@@ -1,0 +1,91 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orxaq_autonomy import router
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self._payload = payload
+        self.status = status
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class RouterTests(unittest.TestCase):
+    def _write_config(self, root: pathlib.Path) -> pathlib.Path:
+        config = {
+            "schema_version": "llm-router.v1",
+            "router": {"strategy": "first_healthy", "fallback_order": ["L0", "L1"]},
+            "lanes": {"L0": ["local"], "L1": ["remote"]},
+            "providers": [
+                {"name": "local", "kind": "openai_compat", "base_url": "http://127.0.0.1:1234/v1", "required": False},
+                {"name": "remote", "kind": "openai_compat", "base_url": "https://example.invalid/v1", "required": True},
+            ],
+        }
+        path = root / "config" / "router.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(config), encoding="utf-8")
+        return path
+
+    def test_run_router_check_reports_up_provider(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = self._write_config(root)
+            output = root / "artifacts" / "router_check.json"
+            with mock.patch(
+                "orxaq_autonomy.router.urllib_request.urlopen",
+                return_value=_FakeResponse({"data": [{"id": "m1"}]}),
+            ):
+                report = router.run_router_check(
+                    root=str(root),
+                    config_path=str(config),
+                    output_path=str(output),
+                    lane="L0",
+                    timeout_sec=5,
+                )
+            self.assertTrue(output.exists())
+            self.assertEqual(report["summary"]["provider_total"], 1)
+            self.assertEqual(report["summary"]["provider_up"], 1)
+            self.assertTrue(report["summary"]["overall_ok"])
+
+    def test_run_router_check_marks_required_down(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config = self._write_config(root)
+            output = root / "artifacts" / "router_check.json"
+            with mock.patch(
+                "orxaq_autonomy.router.urllib_request.urlopen",
+                side_effect=OSError("network unreachable"),
+            ):
+                report = router.run_router_check(
+                    root=str(root),
+                    config_path=str(config),
+                    output_path=str(output),
+                    lane="L1",
+                    timeout_sec=5,
+                )
+            self.assertEqual(report["summary"]["provider_total"], 1)
+            self.assertEqual(report["summary"]["required_down"], 1)
+            self.assertFalse(report["summary"]["overall_ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objective
W3-A `orxaq-ops`: introduce a unified OpenAI-compatible router check surface with lane-aware provider selection and health reporting.

This PR is stacked on top of #31 (`codex/w2-cd-autonomy-mainline`).

## Acceptance Criteria
- [x] Added router config example: `config/router.example.yaml`.
- [x] Added `router-check` CLI command and `make router-check`.
- [x] `router-check` probes providers via `GET /v1/models` and writes `artifacts/router_check.json`.
- [x] Lane filtering + fallback-order support implemented.
- [x] Tests cover router health success/failure paths and CLI wiring.
- [x] Docs added: `docs/ROUTER.md` + README updates.

## How To Run Locally
```bash
make lint
make test
make version-check
make repo-hygiene
python3 -m orxaq_autonomy.cli --root . router-check --config ./config/router.example.yaml --lane L0 --output ./artifacts/router_check.json --strict
```

## Artifacts
- `artifacts/W3_A_run.json`
- `artifacts/W3_A_summary.md`
- `artifacts/W3_A_provider_matrix.md`
- `artifacts/router_check.json`
