### PR TITLE
feat: production dashboard v2 with operator action system

### DIFF
--- a/src/orxaq_autonomy/dashboard_actions.py
+++ b/src/orxaq_autonomy/dashboard_actions.py
@@ -1,0 +1,857 @@
+"""Dashboard action system — mutations, confirmations, and audit logging.
+
+Provides operator actions for steering the swarm pipeline from the dashboard:
+- Task management (reprioritize, unblock, clear errors)
+- Breakglass grant lifecycle (issue, revoke)
+- Git lock healing
+- Runner lifecycle (start, stop, ensure)
+
+All actions are audit-logged, rate-limited, and optionally require two-phase
+confirmation (dry-run preview → confirm with token).
+
+Zero external dependencies beyond the Python standard library.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Callable
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_now_iso() -> str:
+    return _utc_now().isoformat()
+
+
+def _read_json(path: Path) -> dict[str, Any] | list[Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, (dict, list)) else {}
+
+
+def _read_json_dict(path: Path) -> dict[str, Any]:
+    result = _read_json(path)
+    return result if isinstance(result, dict) else {}
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+    """Atomic JSON write using tempfile + fsync + os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n"
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def _read_ndjson(path: Path, *, tail: int = 200) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return []
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    if tail > 0:
+        lines = lines[-tail:]
+    out: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                out.append(obj)
+        except Exception:
+            continue
+    return out
+
+
+def _pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+TASK_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.\-]{0,127}$")
+VALID_DASHBOARD_STATUSES = {"pending", "blocked", "done"}
+MAX_TTL_MINUTES = 1440  # 24 hours
+
+
+# ── Audit Log ────────────────────────────────────────────────────────────────
+
+class ActionAuditLog:
+    """Append-only NDJSON audit log for dashboard actions."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def log(self, entry: dict[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(entry, default=str, sort_keys=True) + "\n"
+        with self._path.open("a", encoding="utf-8") as f:
+            f.write(line)
+
+    def recent(self, tail: int = 100) -> list[dict[str, Any]]:
+        return _read_ndjson(self._path, tail=tail)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+
+# ── Confirmation Tokens ──────────────────────────────────────────────────────
+
+_PENDING_CONFIRMATIONS: dict[str, dict[str, Any]] = {}
+
+
+def generate_confirm_token(action_id: str, params: dict[str, Any]) -> str:
+    """Generate a single-use confirmation token valid for 5 minutes."""
+    nonce = secrets.token_hex(8)
+    token = f"tok-{nonce}"
+    _PENDING_CONFIRMATIONS[token] = {
+        "action_id": action_id,
+        "params_json": json.dumps(params, sort_keys=True, default=str),
+        "created_at": time.time(),
+        "expires_at": time.time() + 300,
+    }
+    # Clean up expired tokens while we're here
+    _cleanup_expired_tokens()
+    return token
+
+
+def validate_confirm_token(token: str, action_id: str) -> bool:
+    """Validate and consume a confirmation token (single-use)."""
+    entry = _PENDING_CONFIRMATIONS.get(token)
+    if not entry:
+        return False
+    if time.time() > entry["expires_at"]:
+        del _PENDING_CONFIRMATIONS[token]
+        return False
+    if entry["action_id"] != action_id:
+        return False
+    del _PENDING_CONFIRMATIONS[token]
+    return True
+
+
+def _cleanup_expired_tokens() -> None:
+    now = time.time()
+    expired = [k for k, v in _PENDING_CONFIRMATIONS.items() if now > v["expires_at"]]
+    for k in expired:
+        del _PENDING_CONFIRMATIONS[k]
+
+
+# ── Rate Limiting ────────────────────────────────────────────────────────────
+
+_RATE_WINDOWS: dict[str, list[float]] = {}
+RATE_LIMIT_GLOBAL = 30
+RATE_LIMIT_HIGH = 5
+
+
+def check_rate_limit(risk_level: str) -> str | None:
+    """Returns error message if rate-limited, else None."""
+    now = time.time()
+    cutoff = now - 60.0
+
+    _RATE_WINDOWS.setdefault("global", [])
+    _RATE_WINDOWS["global"] = [t for t in _RATE_WINDOWS["global"] if t > cutoff]
+    if len(_RATE_WINDOWS["global"]) >= RATE_LIMIT_GLOBAL:
+        return "Rate limit exceeded (30 actions/minute)"
+
+    if risk_level == "high":
+        _RATE_WINDOWS.setdefault("high", [])
+        _RATE_WINDOWS["high"] = [t for t in _RATE_WINDOWS["high"] if t > cutoff]
+        if len(_RATE_WINDOWS["high"]) >= RATE_LIMIT_HIGH:
+            return "Rate limit exceeded for high-risk actions (5/minute)"
+
+    _RATE_WINDOWS["global"].append(now)
+    if risk_level == "high":
+        _RATE_WINDOWS.setdefault("high", []).append(now)
+    return None
+
+
+def reset_rate_limits() -> None:
+    """Reset rate limits (for testing)."""
+    _RATE_WINDOWS.clear()
+
+
+# ── Action Context ───────────────────────────────────────────────────────────
+
+@dataclass
+class ActionContext:
+    """Immutable context for action execution."""
+    artifacts_dir: Path
+    repo_dir: Path | None
+    state_file: Path
+    config_tasks_file: Path
+    audit_log: ActionAuditLog
+
+
+@dataclass
+class ActionResult:
+    """Result of an action execution."""
+    ok: bool
+    action_id: str
+    dry_run: bool
+    message: str
+    detail: dict[str, Any] = field(default_factory=dict)
+    audit_id: str | None = None
+    confirm_token: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "action_id": self.action_id,
+            "dry_run": self.dry_run,
+            "message": self.message,
+            "detail": self.detail,
+            "audit_id": self.audit_id,
+            "confirm_token": self.confirm_token,
+        }
+
+
+def build_context(artifacts_dir: Path, repo_dir: Path | None = None) -> ActionContext:
+    """Build action context from resolved paths."""
+    repo_root = artifacts_dir.parent
+    return ActionContext(
+        artifacts_dir=artifacts_dir,
+        repo_dir=repo_dir,
+        state_file=repo_root / "state" / "state.json",
+        config_tasks_file=repo_root / "config" / "tasks.json",
+        audit_log=ActionAuditLog(artifacts_dir / "autonomy" / "dashboard_actions_audit.ndjson"),
+    )
+
+
+# ── Action Definitions ───────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ActionDef:
+    action_id: str
+    risk_level: str  # "low" | "medium" | "high"
+    description: str
+    requires_confirmation: bool
+    param_schema: dict[str, str]  # param_name -> description
+    handler: Callable[[ActionContext, dict[str, Any], bool], ActionResult]
+
+
+# ── Action Handlers ──────────────────────────────────────────────────────────
+
+def _load_state(ctx: ActionContext) -> dict[str, dict[str, Any]]:
+    """Load task state from state.json."""
+    data = _read_json_dict(ctx.state_file)
+    return {k: v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _load_tasks(ctx: ActionContext) -> list[dict[str, Any]]:
+    """Load tasks from config/tasks.json."""
+    data = _read_json(ctx.config_tasks_file)
+    return data if isinstance(data, list) else []
+
+
+# ── task.reprioritize ────────────────────────────────────────────────────────
+
+def action_task_reprioritize(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    task_id = str(params.get("task_id", ""))
+    new_priority = params.get("new_priority")
+
+    if not task_id or not TASK_ID_PATTERN.match(task_id):
+        return ActionResult(ok=False, action_id="task.reprioritize", dry_run=dry_run,
+                            message=f"Invalid task_id: {task_id!r}")
+
+    try:
+        new_priority = int(new_priority)
+    except (TypeError, ValueError):
+        return ActionResult(ok=False, action_id="task.reprioritize", dry_run=dry_run,
+                            message=f"Invalid priority: {new_priority!r}")
+    if new_priority < 0 or new_priority > 999:
+        return ActionResult(ok=False, action_id="task.reprioritize", dry_run=dry_run,
+                            message="Priority must be 0-999")
+
+    tasks = _load_tasks(ctx)
+    match = None
+    old_priority = None
+    for t in tasks:
+        if isinstance(t, dict) and str(t.get("id", "")) == task_id:
+            match = t
+            old_priority = t.get("priority")
+            break
+
+    if match is None:
+        return ActionResult(ok=False, action_id="task.reprioritize", dry_run=dry_run,
+                            message=f"Task not found in config: {task_id}")
+
+    if dry_run:
+        return ActionResult(ok=True, action_id="task.reprioritize", dry_run=True,
+                            message=f"Would change {task_id} priority from {old_priority} to {new_priority}",
+                            detail={"task_id": task_id, "old_priority": old_priority, "new_priority": new_priority})
+
+    match["priority"] = new_priority
+    _write_json_atomic(ctx.config_tasks_file, tasks)
+
+    return ActionResult(ok=True, action_id="task.reprioritize", dry_run=False,
+                        message=f"Task {task_id} priority changed from {old_priority} to {new_priority}",
+                        detail={"task_id": task_id, "old_priority": old_priority, "new_priority": new_priority})
+
+
+# ── task.update-status ───────────────────────────────────────────────────────
+
+def action_task_update_status(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    task_id = str(params.get("task_id", ""))
+    new_status = str(params.get("new_status", ""))
+
+    if not task_id or not TASK_ID_PATTERN.match(task_id):
+        return ActionResult(ok=False, action_id="task.update-status", dry_run=dry_run,
+                            message=f"Invalid task_id: {task_id!r}")
+
+    if new_status not in VALID_DASHBOARD_STATUSES:
+        return ActionResult(ok=False, action_id="task.update-status", dry_run=dry_run,
+                            message=f"Invalid status: {new_status!r}. Allowed: {', '.join(sorted(VALID_DASHBOARD_STATUSES))}")
+
+    state = _load_state(ctx)
+    if task_id not in state:
+        return ActionResult(ok=False, action_id="task.update-status", dry_run=dry_run,
+                            message=f"Task not found in state: {task_id}")
+
+    current_status = state[task_id].get("status", "unknown")
+
+    if dry_run:
+        return ActionResult(ok=True, action_id="task.update-status", dry_run=True,
+                            message=f"Would change {task_id} from {current_status} to {new_status}",
+                            detail={"task_id": task_id, "current_status": current_status, "new_status": new_status})
+
+    state[task_id]["status"] = new_status
+    state[task_id]["last_update"] = _utc_now_iso()
+    if new_status == "pending":
+        state[task_id]["last_error"] = ""
+        state[task_id]["not_before"] = ""
+    _write_json_atomic(ctx.state_file, state)
+
+    return ActionResult(ok=True, action_id="task.update-status", dry_run=False,
+                        message=f"Task {task_id} status changed from {current_status} to {new_status}",
+                        detail={"task_id": task_id, "previous_status": current_status, "new_status": new_status})
+
+
+# ── task.clear-error ─────────────────────────────────────────────────────────
+
+def action_task_clear_error(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    task_id = str(params.get("task_id", ""))
+
+    if not task_id or not TASK_ID_PATTERN.match(task_id):
+        return ActionResult(ok=False, action_id="task.clear-error", dry_run=dry_run,
+                            message=f"Invalid task_id: {task_id!r}")
+
+    state = _load_state(ctx)
+    if task_id not in state:
+        return ActionResult(ok=False, action_id="task.clear-error", dry_run=dry_run,
+                            message=f"Task not found in state: {task_id}")
+
+    entry = state[task_id]
+    old_error = entry.get("last_error", "")
+    old_failures = entry.get("retryable_failures", 0)
+
+    if dry_run:
+        return ActionResult(ok=True, action_id="task.clear-error", dry_run=True,
+                            message=f"Would clear error for {task_id} (failures: {old_failures})",
+                            detail={"task_id": task_id, "current_error": old_error[:200],
+                                    "retryable_failures": old_failures})
+
+    entry["last_error"] = ""
+    entry["retryable_failures"] = 0
+    entry["not_before"] = ""
+    entry["last_update"] = _utc_now_iso()
+    if entry.get("status") == "blocked":
+        entry["status"] = "pending"
+    _write_json_atomic(ctx.state_file, state)
+
+    return ActionResult(ok=True, action_id="task.clear-error", dry_run=False,
+                        message=f"Cleared error for {task_id} and reset to pending",
+                        detail={"task_id": task_id, "cleared_error": old_error[:200],
+                                "cleared_failures": old_failures})
+
+
+# ── breakglass.grant ─────────────────────────────────────────────────────────
+
+def action_breakglass_grant(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    reason = str(params.get("reason", "")).strip()
+    scope = str(params.get("scope", "")).strip()
+    ttl_minutes = params.get("ttl_minutes", 20)
+    task_allowlist = params.get("task_allowlist", [])
+
+    if not reason:
+        return ActionResult(ok=False, action_id="breakglass.grant", dry_run=dry_run,
+                            message="reason is required")
+    if not scope:
+        return ActionResult(ok=False, action_id="breakglass.grant", dry_run=dry_run,
+                            message="scope is required")
+    try:
+        ttl_minutes = int(ttl_minutes)
+    except (TypeError, ValueError):
+        return ActionResult(ok=False, action_id="breakglass.grant", dry_run=dry_run,
+                            message=f"Invalid ttl_minutes: {ttl_minutes!r}")
+    if ttl_minutes < 1 or ttl_minutes > MAX_TTL_MINUTES:
+        return ActionResult(ok=False, action_id="breakglass.grant", dry_run=dry_run,
+                            message=f"ttl_minutes must be 1-{MAX_TTL_MINUTES}")
+    if not isinstance(task_allowlist, list):
+        task_allowlist = []
+
+    now = _utc_now()
+    grant_id = f"bg-{now.strftime('%Y%m%dT%H%M%SZ')}-{secrets.token_hex(4)}"
+    expires_at = now + timedelta(minutes=ttl_minutes)
+
+    grant = {
+        "grant_id": grant_id,
+        "issued_at": now.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "requested_by": "dashboard_operator",
+        "approved_by": "dashboard_operator",
+        "reason": reason,
+        "scope": scope,
+        "ttl_minutes": ttl_minutes,
+        "task_allowlist": task_allowlist,
+        "rollback_proof": "Grant will auto-expire; revoke via dashboard if needed.",
+    }
+
+    if dry_run:
+        token = generate_confirm_token("breakglass.grant", params)
+        return ActionResult(ok=True, action_id="breakglass.grant", dry_run=True,
+                            message=f"Would issue breakglass grant ({ttl_minutes}m TTL)",
+                            detail=grant, confirm_token=token)
+
+    grants_dir = ctx.artifacts_dir / "autonomy" / "breakglass" / "grants"
+    grants_dir.mkdir(parents=True, exist_ok=True)
+    grant_path = grants_dir / f"{grant_id}.json"
+    _write_json_atomic(grant_path, grant)
+
+    # Also log to privilege_escalations.ndjson
+    escalation_path = ctx.artifacts_dir / "autonomy" / "privilege_escalations.ndjson"
+    escalation_path.parent.mkdir(parents=True, exist_ok=True)
+    escalation_entry = json.dumps({
+        "event_type": "breakglass_grant_created",
+        "grant_id": grant_id,
+        "timestamp": now.isoformat(),
+        "reason": reason,
+        "scope": scope,
+        "source": "dashboard",
+    }, default=str) + "\n"
+    with escalation_path.open("a", encoding="utf-8") as f:
+        f.write(escalation_entry)
+
+    return ActionResult(ok=True, action_id="breakglass.grant", dry_run=False,
+                        message=f"Breakglass grant {grant_id} issued ({ttl_minutes}m TTL)",
+                        detail=grant)
+
+
+# ── breakglass.revoke ────────────────────────────────────────────────────────
+
+def action_breakglass_revoke(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    grant_id = str(params.get("grant_id", "")).strip()
+
+    if not grant_id:
+        return ActionResult(ok=False, action_id="breakglass.revoke", dry_run=dry_run,
+                            message="grant_id is required")
+
+    grants_dir = ctx.artifacts_dir / "autonomy" / "breakglass" / "grants"
+    grant_path = grants_dir / f"{grant_id}.json"
+
+    if not grant_path.exists():
+        return ActionResult(ok=False, action_id="breakglass.revoke", dry_run=dry_run,
+                            message=f"Grant not found: {grant_id}")
+
+    grant_data = _read_json_dict(grant_path)
+
+    if dry_run:
+        token = generate_confirm_token("breakglass.revoke", params)
+        return ActionResult(ok=True, action_id="breakglass.revoke", dry_run=True,
+                            message=f"Would revoke grant {grant_id}",
+                            detail=grant_data, confirm_token=token)
+
+    grant_path.unlink(missing_ok=True)
+
+    # Also update active_grant.json if it references this grant
+    active_path = ctx.artifacts_dir / "autonomy" / "breakglass" / "active_grant.json"
+    if active_path.exists():
+        active = _read_json_dict(active_path)
+        if active.get("grant_id") == grant_id:
+            active_path.unlink(missing_ok=True)
+
+    # Log to privilege_escalations.ndjson
+    escalation_path = ctx.artifacts_dir / "autonomy" / "privilege_escalations.ndjson"
+    escalation_path.parent.mkdir(parents=True, exist_ok=True)
+    escalation_entry = json.dumps({
+        "event_type": "breakglass_grant_revoked",
+        "grant_id": grant_id,
+        "timestamp": _utc_now_iso(),
+        "source": "dashboard",
+    }, default=str) + "\n"
+    with escalation_path.open("a", encoding="utf-8") as f:
+        f.write(escalation_entry)
+
+    return ActionResult(ok=True, action_id="breakglass.revoke", dry_run=False,
+                        message=f"Grant {grant_id} revoked",
+                        detail={"grant_id": grant_id})
+
+
+# ── git.heal-locks ───────────────────────────────────────────────────────────
+
+def action_git_heal_locks(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    if not ctx.repo_dir:
+        return ActionResult(ok=False, action_id="git.heal-locks", dry_run=dry_run,
+                            message="repo_dir not configured")
+
+    git_dir = ctx.repo_dir / ".git"
+    if not git_dir.is_dir():
+        return ActionResult(ok=False, action_id="git.heal-locks", dry_run=dry_run,
+                            message="No .git directory found")
+
+    lock_names = ("index.lock", "HEAD.lock", "packed-refs.lock")
+    found: list[dict[str, Any]] = []
+    now = time.time()
+
+    for name in lock_names:
+        lock_path = git_dir / name
+        if lock_path.exists():
+            try:
+                age = now - lock_path.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            found.append({"name": name, "age_sec": int(age), "path": str(lock_path)})
+
+    if not found:
+        return ActionResult(ok=True, action_id="git.heal-locks", dry_run=dry_run,
+                            message="No stale git lock files found",
+                            detail={"locks_found": 0})
+
+    if dry_run:
+        token = generate_confirm_token("git.heal-locks", params)
+        return ActionResult(ok=True, action_id="git.heal-locks", dry_run=True,
+                            message=f"Found {len(found)} git lock file(s) to remove",
+                            detail={"locks": found}, confirm_token=token)
+
+    removed: list[str] = []
+    for lock in found:
+        lock_path = Path(lock["path"])
+        if lock_path.exists():
+            lock_path.unlink(missing_ok=True)
+            removed.append(lock["name"])
+
+    return ActionResult(ok=True, action_id="git.heal-locks", dry_run=False,
+                        message=f"Removed {len(removed)} git lock file(s): {', '.join(removed)}",
+                        detail={"removed": removed})
+
+
+# ── runner.release-lock ──────────────────────────────────────────────────────
+
+def action_runner_release_lock(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    lock_path = ctx.artifacts_dir / "autonomy" / "runner.lock"
+
+    if not lock_path.exists():
+        return ActionResult(ok=True, action_id="runner.release-lock", dry_run=dry_run,
+                            message="No runner lock file found",
+                            detail={"lock_exists": False})
+
+    lock_data = _read_json_dict(lock_path)
+    lock_pid = int(lock_data.get("pid", 0)) if str(lock_data.get("pid", "")).isdigit() else 0
+    pid_alive = _pid_is_running(lock_pid) if lock_pid else False
+
+    if pid_alive:
+        return ActionResult(ok=False, action_id="runner.release-lock", dry_run=dry_run,
+                            message=f"Runner process is still alive (pid={lock_pid}). Cannot release lock.",
+                            detail={"pid": lock_pid, "alive": True})
+
+    if dry_run:
+        token = generate_confirm_token("runner.release-lock", params)
+        return ActionResult(ok=True, action_id="runner.release-lock", dry_run=True,
+                            message=f"Would remove stale runner lock (pid={lock_pid}, not running)",
+                            detail=lock_data, confirm_token=token)
+
+    lock_path.unlink(missing_ok=True)
+
+    return ActionResult(ok=True, action_id="runner.release-lock", dry_run=False,
+                        message=f"Stale runner lock removed (pid={lock_pid})",
+                        detail={"removed_pid": lock_pid})
+
+
+# ── runner.stop ──────────────────────────────────────────────────────────────
+
+def action_runner_stop(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    reason = str(params.get("reason", "Manual stop from dashboard")).strip()
+
+    if dry_run:
+        token = generate_confirm_token("runner.stop", params)
+        lock_path = ctx.artifacts_dir / "autonomy" / "runner.lock"
+        lock_data = _read_json_dict(lock_path)
+        return ActionResult(ok=True, action_id="runner.stop", dry_run=True,
+                            message=f"Would stop autonomy runner: {reason}",
+                            detail={"reason": reason, "lock_data": lock_data},
+                            confirm_token=token)
+
+    try:
+        result = subprocess.run(
+            ["python3", "-m", "orxaq_autonomy", "--root", str(ctx.artifacts_dir.parent), "stop",
+             "--reason", reason],
+            capture_output=True, text=True, check=False, timeout=30,
+            cwd=str(ctx.artifacts_dir.parent),
+        )
+        return ActionResult(ok=result.returncode == 0, action_id="runner.stop", dry_run=False,
+                            message=f"Runner stop {'succeeded' if result.returncode == 0 else 'failed'}",
+                            detail={"stdout": result.stdout[:500], "stderr": result.stderr[:500],
+                                    "returncode": result.returncode, "reason": reason})
+    except Exception as exc:
+        return ActionResult(ok=False, action_id="runner.stop", dry_run=False,
+                            message=f"Failed to stop runner: {exc}",
+                            detail={"error": str(exc)})
+
+
+# ── runner.start ─────────────────────────────────────────────────────────────
+
+def action_runner_start(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    if dry_run:
+        token = generate_confirm_token("runner.start", params)
+        lock_path = ctx.artifacts_dir / "autonomy" / "runner.lock"
+        lock_exists = lock_path.exists()
+        return ActionResult(ok=True, action_id="runner.start", dry_run=True,
+                            message="Would start autonomy runner",
+                            detail={"lock_exists": lock_exists},
+                            confirm_token=token)
+
+    try:
+        result = subprocess.run(
+            ["python3", "-m", "orxaq_autonomy", "--root", str(ctx.artifacts_dir.parent), "start"],
+            capture_output=True, text=True, check=False, timeout=30,
+            cwd=str(ctx.artifacts_dir.parent),
+        )
+        return ActionResult(ok=result.returncode == 0, action_id="runner.start", dry_run=False,
+                            message=f"Runner start {'succeeded' if result.returncode == 0 else 'failed'}",
+                            detail={"stdout": result.stdout[:500], "stderr": result.stderr[:500],
+                                    "returncode": result.returncode})
+    except Exception as exc:
+        return ActionResult(ok=False, action_id="runner.start", dry_run=False,
+                            message=f"Failed to start runner: {exc}",
+                            detail={"error": str(exc)})
+
+
+# ── runner.ensure ────────────────────────────────────────────────────────────
+
+def action_runner_ensure(ctx: ActionContext, params: dict[str, Any], dry_run: bool) -> ActionResult:
+    if dry_run:
+        token = generate_confirm_token("runner.ensure", params)
+        lock_path = ctx.artifacts_dir / "autonomy" / "runner.lock"
+        lock_data = _read_json_dict(lock_path)
+        return ActionResult(ok=True, action_id="runner.ensure", dry_run=True,
+                            message="Would ensure autonomy runner is alive (restart if stale)",
+                            detail={"lock_data": lock_data},
+                            confirm_token=token)
+
+    try:
+        result = subprocess.run(
+            ["python3", "-m", "orxaq_autonomy", "--root", str(ctx.artifacts_dir.parent), "ensure"],
+            capture_output=True, text=True, check=False, timeout=30,
+            cwd=str(ctx.artifacts_dir.parent),
+        )
+        return ActionResult(ok=result.returncode == 0, action_id="runner.ensure", dry_run=False,
+                            message=f"Runner ensure {'succeeded' if result.returncode == 0 else 'failed'}",
+                            detail={"stdout": result.stdout[:500], "stderr": result.stderr[:500],
+                                    "returncode": result.returncode})
+    except Exception as exc:
+        return ActionResult(ok=False, action_id="runner.ensure", dry_run=False,
+                            message=f"Failed to ensure runner: {exc}",
+                            detail={"error": str(exc)})
+
+
+# ── Action Registry ──────────────────────────────────────────────────────────
+
+ACTIONS: dict[str, ActionDef] = {
+    "task.reprioritize": ActionDef(
+        action_id="task.reprioritize",
+        risk_level="low",
+        description="Change a task's priority in the backlog",
+        requires_confirmation=False,
+        param_schema={"task_id": "Task identifier", "new_priority": "New priority (0-999, lower = higher)"},
+        handler=action_task_reprioritize,
+    ),
+    "task.update-status": ActionDef(
+        action_id="task.update-status",
+        risk_level="low",
+        description="Set a task's status (pending, blocked, done)",
+        requires_confirmation=False,
+        param_schema={"task_id": "Task identifier", "new_status": "New status: pending | blocked | done"},
+        handler=action_task_update_status,
+    ),
+    "task.clear-error": ActionDef(
+        action_id="task.clear-error",
+        risk_level="low",
+        description="Clear error state and reset task for retry",
+        requires_confirmation=False,
+        param_schema={"task_id": "Task identifier"},
+        handler=action_task_clear_error,
+    ),
+    "breakglass.grant": ActionDef(
+        action_id="breakglass.grant",
+        risk_level="medium",
+        description="Issue a time-limited breakglass privilege grant",
+        requires_confirmation=True,
+        param_schema={
+            "reason": "Why the grant is needed",
+            "scope": "What the grant allows",
+            "ttl_minutes": "Grant duration in minutes (1-1440)",
+            "task_allowlist": "List of task IDs allowed to use the grant",
+        },
+        handler=action_breakglass_grant,
+    ),
+    "breakglass.revoke": ActionDef(
+        action_id="breakglass.revoke",
+        risk_level="medium",
+        description="Revoke an active breakglass grant",
+        requires_confirmation=True,
+        param_schema={"grant_id": "Grant ID to revoke"},
+        handler=action_breakglass_revoke,
+    ),
+    "git.heal-locks": ActionDef(
+        action_id="git.heal-locks",
+        risk_level="medium",
+        description="Remove stale git lock files (.git/index.lock etc.)",
+        requires_confirmation=True,
+        param_schema={},
+        handler=action_git_heal_locks,
+    ),
+    "runner.release-lock": ActionDef(
+        action_id="runner.release-lock",
+        risk_level="medium",
+        description="Remove stale runner lock when process is dead",
+        requires_confirmation=True,
+        param_schema={},
+        handler=action_runner_release_lock,
+    ),
+    "runner.stop": ActionDef(
+        action_id="runner.stop",
+        risk_level="high",
+        description="Stop the autonomy runner",
+        requires_confirmation=True,
+        param_schema={"reason": "Reason for stopping (optional)"},
+        handler=action_runner_stop,
+    ),
+    "runner.start": ActionDef(
+        action_id="runner.start",
+        risk_level="high",
+        description="Start the autonomy runner",
+        requires_confirmation=True,
+        param_schema={},
+        handler=action_runner_start,
+    ),
+    "runner.ensure": ActionDef(
+        action_id="runner.ensure",
+        risk_level="high",
+        description="Ensure runner is alive, restart if stale",
+        requires_confirmation=True,
+        param_schema={},
+        handler=action_runner_ensure,
+    ),
+}
+
+
+def get_action_catalog() -> list[dict[str, Any]]:
+    """Return the action catalog for the GET /api/v2/actions endpoint."""
+    return [
+        {
+            "action_id": a.action_id,
+            "risk_level": a.risk_level,
+            "description": a.description,
+            "requires_confirmation": a.requires_confirmation,
+            "param_schema": a.param_schema,
+        }
+        for a in ACTIONS.values()
+    ]
+
+
+# ── Action Dispatcher ────────────────────────────────────────────────────────
+
+def dispatch_action(
+    *,
+    action_id: str,
+    params: dict[str, Any],
+    confirm_token: str,
+    dry_run: bool,
+    artifacts_dir: Path,
+    repo_dir: Path | None,
+) -> ActionResult:
+    """Main entry point for executing a dashboard action."""
+    # Look up action
+    action_def = ACTIONS.get(action_id)
+    if not action_def:
+        return ActionResult(ok=False, action_id=action_id, dry_run=dry_run,
+                            message=f"Unknown action: {action_id}")
+
+    # Rate limit check
+    rate_error = check_rate_limit(action_def.risk_level)
+    if rate_error:
+        return ActionResult(ok=False, action_id=action_id, dry_run=dry_run,
+                            message=rate_error)
+
+    # Confirmation check for non-dry-run requests on actions that require confirmation
+    if action_def.requires_confirmation and not dry_run:
+        if not confirm_token:
+            return ActionResult(
+                ok=False, action_id=action_id, dry_run=False,
+                message="This action requires confirmation. POST with dry_run=true first to preview, "
+                        "then use the returned confirm_token to execute.")
+        if not validate_confirm_token(confirm_token, action_id):
+            return ActionResult(
+                ok=False, action_id=action_id, dry_run=False,
+                message="Invalid or expired confirmation token. Request a new preview with dry_run=true.")
+
+    # Build context and execute
+    ctx = build_context(artifacts_dir, repo_dir)
+    start_time = time.time()
+
+    try:
+        result = action_def.handler(ctx, params, dry_run)
+    except Exception as exc:
+        result = ActionResult(ok=False, action_id=action_id, dry_run=dry_run,
+                              message=f"Action failed: {exc}",
+                              detail={"error": str(exc)})
+
+    duration_ms = int((time.time() - start_time) * 1000)
+
+    # Audit log (skip for dry-runs — only log actual executions)
+    if not dry_run:
+        audit_id = f"act-{_utc_now().strftime('%Y%m%dT%H%M%SZ')}-{secrets.token_hex(4)}"
+        result.audit_id = audit_id
+        ctx.audit_log.log({
+            "audit_id": audit_id,
+            "timestamp": _utc_now_iso(),
+            "action_id": action_id,
+            "risk_level": action_def.risk_level,
+            "params": params,
+            "dry_run": False,
+            "result_ok": result.ok,
+            "result_message": result.message,
+            "duration_ms": duration_ms,
+        })
+
+    return result

--- a/src/orxaq_autonomy/dashboard_aegis.html
+++ b/src/orxaq_autonomy/dashboard_aegis.html
@@ -1,0 +1,582 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AEGIS — Temporal Flow Navigator</title>
+<script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--bg:#06080c;--surface:rgba(12,18,28,0.9);--border:rgba(40,60,90,0.3);--text:#a0b8d0;--muted:#405060;--accent:#00a8ff;--codex:#00c8ff;--gemini:#ff8800;--claude:#a855f7;--ok:#00e07a;--warn:#ffaa00;--crit:#ff3050}
+html,body{height:100%;overflow:hidden}
+body{background:var(--bg);font-family:'SF Pro Text','Inter','Helvetica Neue',sans-serif;color:var(--text)}
+
+/* Ambient background */
+.ambient{position:fixed;top:0;left:0;right:0;bottom:0;z-index:0;transition:background 2s ease}
+.ambient.healthy{background:radial-gradient(ellipse at 50% 30%,rgba(0,40,80,0.15) 0%,rgba(6,8,12,1) 70%)}
+.ambient.warning{background:radial-gradient(ellipse at 50% 30%,rgba(80,50,0,0.12) 0%,rgba(6,8,12,1) 70%)}
+.ambient.critical{background:radial-gradient(ellipse at 50% 30%,rgba(80,10,20,0.12) 0%,rgba(6,8,12,1) 70%)}
+
+/* Layout */
+.app{position:relative;z-index:1;height:100vh;display:grid;grid-template-rows:auto 1fr auto;grid-template-columns:260px 1fr 280px;grid-template-areas:"header header header" "sidebar river detail" "footer footer footer"}
+
+/* Header */
+.header{grid-area:header;display:flex;align-items:center;justify-content:space-between;padding:10px 20px;border-bottom:1px solid var(--border);background:var(--surface);backdrop-filter:blur(12px)}
+.header h1{font-size:13px;font-weight:600;letter-spacing:0.08em;color:var(--accent)}
+.header h1 span{color:var(--muted);font-weight:400;margin-left:8px;font-size:11px}
+.health-orb{width:32px;height:32px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;cursor:pointer;transition:all 0.3s}
+.health-orb.green{background:rgba(0,224,122,0.12);border:2px solid rgba(0,224,122,0.4);color:var(--ok);box-shadow:0 0 12px rgba(0,224,122,0.1)}
+.health-orb.amber{background:rgba(255,170,0,0.12);border:2px solid rgba(255,170,0,0.4);color:var(--warn);box-shadow:0 0 12px rgba(255,170,0,0.1)}
+.health-orb.red{background:rgba(255,48,80,0.12);border:2px solid rgba(255,48,80,0.4);color:var(--crit);box-shadow:0 0 12px rgba(255,48,80,0.1)}
+.header-stats{display:flex;gap:20px;font-size:10px}
+.header-stat{display:flex;flex-direction:column;align-items:center;gap:1px}
+.header-stat-label{font-size:8px;color:var(--muted);text-transform:uppercase;letter-spacing:0.1em}
+.header-stat-val{font-size:13px;font-weight:700;font-family:'SF Mono',monospace}
+
+/* Sidebar: Agent Threads */
+.sidebar{grid-area:sidebar;border-right:1px solid var(--border);padding:12px;overflow-y:auto;background:var(--surface);backdrop-filter:blur(8px)}
+.sidebar::-webkit-scrollbar{width:3px}.sidebar::-webkit-scrollbar-thumb{background:var(--border)}
+.section-title{font-size:8px;color:var(--muted);text-transform:uppercase;letter-spacing:0.15em;margin-bottom:8px;padding-bottom:6px;border-bottom:1px solid var(--border)}
+.agent-card{padding:10px;margin-bottom:6px;border-radius:6px;background:rgba(20,30,45,0.6);border:1px solid var(--border);cursor:pointer;transition:all 0.2s}
+.agent-card:hover{background:rgba(30,45,65,0.6);border-color:rgba(60,90,130,0.4)}
+.agent-card.selected{border-color:var(--accent);background:rgba(0,168,255,0.05)}
+.agent-card-header{display:flex;align-items:center;gap:6px;margin-bottom:6px}
+.agent-dot{width:8px;height:8px;border-radius:50%}
+.agent-name{font-size:11px;font-weight:600;flex:1}
+.agent-status{font-size:8px;padding:2px 6px;border-radius:3px;font-weight:600;text-transform:uppercase;letter-spacing:0.05em}
+.agent-status.in_progress{background:rgba(0,168,255,0.12);color:var(--accent)}
+.agent-status.done{background:rgba(0,224,122,0.1);color:var(--ok)}
+.agent-status.blocked{background:rgba(255,48,80,0.1);color:var(--crit)}
+.agent-status.pending{background:rgba(255,170,0,0.08);color:var(--warn)}
+.agent-meta{display:grid;grid-template-columns:1fr 1fr;gap:4px;font-size:9px}
+.agent-meta-item{display:flex;justify-content:space-between}
+.agent-meta-label{color:var(--muted)}
+.agent-meta-val{color:var(--text);font-family:'SF Mono',monospace}
+.progress-bar{height:3px;background:rgba(40,60,90,0.3);border-radius:2px;margin-top:6px;overflow:hidden}
+.progress-fill{height:100%;border-radius:2px;transition:width 0.6s ease}
+
+/* River: SVG Timeline */
+.river{grid-area:river;overflow-x:auto;overflow-y:hidden;position:relative;cursor:grab}
+.river:active{cursor:grabbing}
+.river svg{display:block}
+.river-label{font-family:'SF Mono',monospace;font-size:9px;fill:var(--muted)}
+.river-lane-label{font-size:10px;fill:var(--text);font-weight:600}
+.river-node{cursor:pointer;transition:opacity 0.2s}
+.river-node:hover{opacity:1 !important}
+.tooltip{position:fixed;background:rgba(8,14,24,0.95);border:1px solid var(--border);border-radius:6px;padding:10px 14px;font-size:10px;max-width:300px;z-index:100;pointer-events:none;backdrop-filter:blur(8px);box-shadow:0 4px 16px rgba(0,0,0,0.4)}
+.tooltip .tt-title{font-weight:600;color:var(--accent);margin-bottom:4px;font-size:11px}
+.tooltip .tt-row{display:flex;justify-content:space-between;gap:12px;padding:1px 0}
+.tooltip .tt-label{color:var(--muted)}.tooltip .tt-val{color:var(--text);font-family:'SF Mono',monospace}
+
+/* Detail panel */
+.detail{grid-area:detail;border-left:1px solid var(--border);padding:12px;overflow-y:auto;background:var(--surface);backdrop-filter:blur(8px)}
+.detail::-webkit-scrollbar{width:3px}.detail::-webkit-scrollbar-thumb{background:var(--border)}
+.detail-empty{display:flex;align-items:center;justify-content:center;height:100%;font-size:11px;color:var(--muted);text-align:center;padding:20px}
+.commit-item{padding:8px;margin:4px 0;border-radius:4px;background:rgba(20,30,45,0.4);border-left:2px solid var(--border);font-size:10px}
+.commit-hash{font-family:'SF Mono',monospace;color:var(--accent)}
+.commit-msg{color:var(--text);margin:2px 0}
+.commit-meta{font-size:8px;color:var(--muted)}
+.endpoint-item{display:flex;align-items:center;gap:8px;padding:6px 8px;margin:3px 0;border-radius:4px;background:rgba(20,30,45,0.3);font-size:10px}
+.endpoint-dot{width:6px;height:6px;border-radius:50%}
+
+/* Footer */
+.footer{grid-area:footer;display:flex;align-items:center;justify-content:space-between;padding:6px 20px;border-top:1px solid var(--border);background:var(--surface);backdrop-filter:blur(12px);font-size:9px;color:var(--muted)}
+
+/* Responsive */
+@media(max-width:1000px){.app{grid-template-columns:1fr;grid-template-areas:"header" "river" "footer"}.sidebar,.detail{display:none}}
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel">
+const { useState, useEffect, useRef, useMemo, useCallback } = React;
+
+// ═══════════════════════════════════════════════════════
+// DATA — Mirrors real orxaq-ops artifact structures
+// ═══════════════════════════════════════════════════════
+const LANES = [
+  { id:'codex-governance', owner:'codex', status:'done', tasks_done:4, tasks_total:4, cycles:12, cost:0.22, heartbeat_age:3,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:2, type:'task', label:'governance-e2e selected' },
+      { t:5, type:'routing', label:'gpt-5.3-codex (static)' },
+      { t:8, type:'commit', label:'breakglass policy v2.1' },
+      { t:11, type:'done', label:'All 4 tasks complete ✓' },
+    ]},
+  { id:'codex-routellm-npv', owner:'codex', status:'in_progress', tasks_done:2, tasks_total:5, cycles:38, cost:0.45, heartbeat_age:8,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:3, type:'task', label:'npv-sensitivity selected' },
+      { t:6, type:'routing', label:'RouteLLM → liquid/lfm2.5' },
+      { t:9, type:'commit', label:'NPV calculation engine' },
+      { t:14, type:'task', label:'discount-rate sweep' },
+      { t:18, type:'routing', label:'gpt-5.3-codex (fallback)' },
+      { t:22, type:'commit', label:'sensitivity matrices' },
+      { t:28, type:'task', label:'visualization layer' },
+      { t:33, type:'progress', label:'Cycle 38 in progress' },
+    ]},
+  { id:'codex-dashboard-todo', owner:'codex', status:'pending', tasks_done:0, tasks_total:1, cycles:8, cost:0.12, heartbeat_age:5,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:2, type:'task', label:'todo-metrics-fix selected' },
+      { t:4, type:'error', label:'--ask-for-approval unexpected' },
+      { t:6, type:'retry', label:'Retry #2 (git lock)' },
+      { t:8, type:'error', label:'Retry #3 (deadlock recovery)' },
+      { t:10, type:'wait', label:'Cooldown 10s before retry' },
+    ]},
+  { id:'codex-dashboard-ui', owner:'codex', status:'in_progress', tasks_done:1, tasks_total:3, cycles:15, cost:0.18, heartbeat_age:2,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:3, type:'task', label:'accessibility-audit' },
+      { t:7, type:'commit', label:'ARIA labels for metrics' },
+      { t:10, type:'done', label:'Task 1/3 complete' },
+      { t:13, type:'task', label:'keyboard-nav pass 2/3' },
+      { t:16, type:'progress', label:'Scanning tab order' },
+    ]},
+  { id:'codex-rpa-security', owner:'codex', status:'done', tasks_done:3, tasks_total:3, cycles:22, cost:0.31, heartbeat_age:120,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:4, type:'task', label:'xss-vector-scan' },
+      { t:8, type:'commit', label:'Input sanitization' },
+      { t:12, type:'task', label:'csrf-hardening' },
+      { t:16, type:'commit', label:'Token validation' },
+      { t:19, type:'done', label:'All XSS vectors patched ✓' },
+    ]},
+  { id:'gemini-skin-regression', owner:'gemini', status:'blocked', tasks_done:2, tasks_total:4, cycles:9, cost:0.08, heartbeat_age:45,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:3, type:'task', label:'skin-parity-check' },
+      { t:5, type:'routing', label:'gemini-2.5-flash' },
+      { t:7, type:'commit', label:'Skin test fixtures' },
+      { t:10, type:'blocked', label:'Merge conflict: skins.py' },
+    ]},
+  { id:'gemini-rln-tests', owner:'gemini', status:'done', tasks_done:5, tasks_total:5, cycles:30, cost:0.15, heartbeat_age:200,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:4, type:'task', label:'semantic-validation' },
+      { t:8, type:'commit', label:'Regression suite v1' },
+      { t:12, type:'task', label:'edge-case coverage' },
+      { t:16, type:'commit', label:'Fuzzing harness' },
+      { t:20, type:'done', label:'All semantic tests green ✓' },
+    ]},
+  { id:'claude-release-audit', owner:'claude', status:'in_progress', tasks_done:1, tasks_total:2, cycles:6, cost:0.09, heartbeat_age:15,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:3, type:'task', label:'phase32-release-check' },
+      { t:6, type:'progress', label:'Scanning signoff integrity' },
+    ]},
+  { id:'claude-collab-health', owner:'claude', status:'done', tasks_done:2, tasks_total:2, cycles:4, cost:0.03, heartbeat_age:300,
+    events: [
+      { t:0, type:'start', label:'Lane started' },
+      { t:2, type:'task', label:'collab-health-scan' },
+      { t:4, type:'done', label:'Health report generated ✓' },
+    ]},
+];
+
+const GIT_COMMITS = [
+  { hash:'a3f2c1d', msg:'fix(dashboard): ARIA labels for metric cards', author:'codex', time:2, branch:'codex/issue-13-dashboard-accessibility' },
+  { hash:'8b1e4f7', msg:'test(rln): add semantic regression suite', author:'gemini', time:5, branch:'gemini/rln-semantic-tests' },
+  { hash:'c5d9a2b', msg:'chore(ops): restore swarm runtime v1', author:'codex', time:12, branch:'codex/restore-swarm-runtime-v1' },
+  { hash:'f7e3b08', msg:'feat(rpa): XSS vector hardening', author:'codex', time:18, branch:'codex/rpa-security-fixes' },
+  { hash:'2a8c1d5', msg:'docs(governance): breakglass policy v2.1', author:'codex', time:25, branch:'codex/governance-e2e' },
+  { hash:'9d4f2e1', msg:'fix(skin): parity test fixtures', author:'gemini', time:30, branch:'gemini/skin-regression' },
+  { hash:'b7c3a90', msg:'feat(npv): discount rate sensitivity', author:'codex', time:35, branch:'codex/routellm-npv' },
+];
+
+const ENDPOINTS = [
+  { id:'lmstudio-node-1', ok:true, latency:2.4, models:11, provider:'local' },
+  { id:'claude-primary', ok:false, latency:101.4, provider:'anthropic', error:'401 auth' },
+  { id:'openai-codex', ok:true, latency:45.2, models:3, provider:'openai' },
+];
+
+const METRICS = {
+  responses:445, cost:1.68, tokens:1055013, passRate:0.481,
+  acceptRate:0.524, latency:90.26, routellmRate:0.438,
+  budget_cap:100, budget_spent:1.68,
+};
+
+const ALERTS = [
+  { sev:'high', msg:'gemini-skin-regression blocked: merge conflict' },
+  { sev:'medium', msg:'codex-dashboard-todo: 8 deadlock recoveries' },
+  { sev:'medium', msg:'claude-collab-health: stale heartbeat (300s)' },
+];
+
+const ownerColor = { codex:'#00c8ff', gemini:'#ff8800', claude:'#a855f7' };
+const statusColor = { done:'#00e07a', in_progress:'#00a8ff', blocked:'#ff3050', pending:'#ffaa00' };
+const eventColor = {
+  start:'#405060', task:'#00a8ff', routing:'#8855cc', commit:'#00e07a',
+  done:'#00e07a', error:'#ff3050', blocked:'#ff3050', retry:'#ffaa00',
+  progress:'#00a8ff', wait:'#ffaa00',
+};
+
+// ═══════════════════════════════════════════════════════
+// COMPONENTS
+// ═══════════════════════════════════════════════════════
+
+function App() {
+  const [selectedLane, setSelectedLane] = useState(null);
+  const [tooltip, setTooltip] = useState(null);
+  const [clock, setClock] = useState('');
+  const riverRef = useRef(null);
+
+  useEffect(() => {
+    const iv = setInterval(() => setClock(new Date().toISOString().slice(11,19)+'Z'), 1000);
+    return () => clearInterval(iv);
+  }, []);
+
+  const healthStatus = ALERTS.some(a => a.sev === 'high') ? 'warning' :
+                        ALERTS.length > 0 ? 'warning' : 'healthy';
+
+  return (
+    <>
+      <div className={`ambient ${healthStatus}`} />
+      <div className="app">
+        <Header clock={clock} healthStatus={healthStatus} />
+        <Sidebar lanes={LANES} selected={selectedLane} onSelect={setSelectedLane} />
+        <River lanes={LANES} commits={GIT_COMMITS} onTooltip={setTooltip} ref={riverRef} />
+        <Detail lane={selectedLane ? LANES.find(l=>l.id===selectedLane) : null} />
+        <Footer />
+      </div>
+      {tooltip && <Tooltip {...tooltip} />}
+    </>
+  );
+}
+
+function Header({ clock, healthStatus }) {
+  const orbClass = healthStatus === 'healthy' ? 'green' : healthStatus === 'warning' ? 'amber' : 'red';
+  return (
+    <div className="header">
+      <div style={{display:'flex',alignItems:'center',gap:12}}>
+        <div className={`health-orb ${orbClass}`} title="System health">
+          {ALERTS.length || '✓'}
+        </div>
+        <h1>AEGIS<span>Temporal Flow Navigator</span></h1>
+      </div>
+      <div className="header-stats">
+        <div className="header-stat"><span className="header-stat-label">Responses</span><span className="header-stat-val" style={{color:'var(--accent)'}}>{METRICS.responses}</span></div>
+        <div className="header-stat"><span className="header-stat-label">Cost</span><span className="header-stat-val">${METRICS.cost.toFixed(2)}</span></div>
+        <div className="header-stat"><span className="header-stat-label">Tokens</span><span className="header-stat-val">{(METRICS.tokens/1000).toFixed(0)}K</span></div>
+        <div className="header-stat"><span className="header-stat-label">Pass Rate</span><span className="header-stat-val" style={{color:METRICS.passRate<0.5?'var(--warn)':'var(--ok)'}}>{(METRICS.passRate*100).toFixed(0)}%</span></div>
+        <div className="header-stat"><span className="header-stat-label">Latency</span><span className="header-stat-val">{METRICS.latency.toFixed(0)}s</span></div>
+        <div className="header-stat"><span className="header-stat-label">Budget</span><span className="header-stat-val">${(METRICS.budget_cap - METRICS.budget_spent).toFixed(0)}</span></div>
+        <div className="header-stat"><span className="header-stat-label">UTC</span><span className="header-stat-val" style={{color:'var(--muted)'}}>{clock}</span></div>
+      </div>
+    </div>
+  );
+}
+
+function Sidebar({ lanes, selected, onSelect }) {
+  const grouped = { codex: [], gemini: [], claude: [] };
+  lanes.forEach(l => (grouped[l.owner] || []).push(l));
+
+  return (
+    <div className="sidebar">
+      {Object.entries(grouped).map(([owner, ownerLanes]) => (
+        <div key={owner}>
+          <div className="section-title" style={{color:ownerColor[owner]}}>{owner.toUpperCase()} — {ownerLanes.length} lanes</div>
+          {ownerLanes.map(lane => (
+            <div key={lane.id}
+              className={`agent-card ${selected === lane.id ? 'selected' : ''}`}
+              onClick={() => onSelect(selected === lane.id ? null : lane.id)}>
+              <div className="agent-card-header">
+                <div className="agent-dot" style={{background:ownerColor[owner],boxShadow:`0 0 6px ${ownerColor[owner]}`}} />
+                <div className="agent-name" style={{color:ownerColor[owner]}}>{lane.id.replace(`${owner}-`,'')}</div>
+                <div className={`agent-status ${lane.status}`}>{lane.status.replace('_',' ')}</div>
+              </div>
+              <div className="agent-meta">
+                <div className="agent-meta-item"><span className="agent-meta-label">Tasks</span><span className="agent-meta-val">{lane.tasks_done}/{lane.tasks_total}</span></div>
+                <div className="agent-meta-item"><span className="agent-meta-label">Cycles</span><span className="agent-meta-val">{lane.cycles}</span></div>
+                <div className="agent-meta-item"><span className="agent-meta-label">Cost</span><span className="agent-meta-val">${lane.cost.toFixed(2)}</span></div>
+                <div className="agent-meta-item"><span className="agent-meta-label">HB</span><span className="agent-meta-val" style={{color:lane.heartbeat_age>120?'var(--warn)':'inherit'}}>{lane.heartbeat_age}s</span></div>
+              </div>
+              <div className="progress-bar">
+                <div className="progress-fill" style={{width:`${(lane.tasks_done/lane.tasks_total)*100}%`,background:statusColor[lane.status]}} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const River = React.forwardRef(({ lanes, commits, onTooltip }, ref) => {
+  const svgRef = useRef(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, scrollLeft: 0 });
+
+  const rowH = 56;
+  const padding = { top: 40, left: 20, right: 40 };
+  const maxT = Math.max(...lanes.flatMap(l => l.events.map(e => e.t)), ...commits.map(c => c.time));
+  const timeScale = 28; // px per time unit
+  const svgW = padding.left + maxT * timeScale + padding.right + 200;
+  const svgH = padding.top + lanes.length * rowH + 60;
+
+  // Drag to pan
+  const onMouseDown = (e) => {
+    setIsDragging(true);
+    setDragStart({ x: e.clientX, scrollLeft: ref.current?.scrollLeft || 0 });
+  };
+  const onMouseMove = useCallback((e) => {
+    if (!isDragging || !ref.current) return;
+    ref.current.scrollLeft = dragStart.scrollLeft - (e.clientX - dragStart.x);
+  }, [isDragging, dragStart]);
+  const onMouseUp = () => setIsDragging(false);
+
+  useEffect(() => {
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    return () => { window.removeEventListener('mousemove', onMouseMove); window.removeEventListener('mouseup', onMouseUp); };
+  }, [onMouseMove]);
+
+  // Time axis ticks
+  const ticks = [];
+  for (let t = 0; t <= maxT; t += 5) ticks.push(t);
+
+  return (
+    <div className="river" ref={ref} onMouseDown={onMouseDown}>
+      <svg ref={svgRef} width={svgW} height={svgH} style={{minWidth:svgW}}>
+        {/* Time axis */}
+        {ticks.map(t => (
+          <g key={t}>
+            <line x1={padding.left + t * timeScale} y1={padding.top - 10}
+                  x2={padding.left + t * timeScale} y2={svgH}
+                  stroke="rgba(40,60,90,0.15)" strokeWidth={1} />
+            <text x={padding.left + t * timeScale} y={padding.top - 16}
+                  className="river-label" textAnchor="middle">-{maxT - t}m</text>
+          </g>
+        ))}
+
+        {/* Lane streams */}
+        {lanes.map((lane, li) => {
+          const y = padding.top + li * rowH + rowH / 2;
+          const color = ownerColor[lane.owner];
+          const events = lane.events;
+
+          // Stream path (flowing line)
+          const points = events.map(e => [padding.left + e.t * timeScale, y]);
+          // Extend to current time for in-progress
+          if (lane.status === 'in_progress') {
+            points.push([padding.left + (maxT + 2) * timeScale, y]);
+          }
+
+          const pathD = points.length > 1
+            ? `M${points[0][0]},${points[0][1]}` + points.slice(1).map(([x,py]) => {
+                const prevX = points[points.indexOf(points.find(p=>p[0]===x&&p[1]===py))-1]?.[0] || points[0][0];
+                const cpx = (prevX + x) / 2;
+                return `C${cpx},${py} ${cpx},${py} ${x},${py}`;
+              }).join('')
+            : '';
+
+          return (
+            <g key={lane.id}>
+              {/* Stream glow */}
+              <path d={pathD} fill="none" stroke={color} strokeWidth={lane.status === 'in_progress' ? 6 : 3}
+                    strokeOpacity={0.08} strokeLinecap="round" />
+              {/* Stream line */}
+              <path d={pathD} fill="none" stroke={color}
+                    strokeWidth={lane.status === 'in_progress' ? 2.5 : 1.5}
+                    strokeOpacity={lane.status === 'done' ? 0.3 : lane.status === 'blocked' ? 0.4 : 0.6}
+                    strokeLinecap="round"
+                    strokeDasharray={lane.status === 'blocked' ? '4,4' : 'none'} />
+
+              {/* Event nodes */}
+              {events.map((evt, ei) => {
+                const ex = padding.left + evt.t * timeScale;
+                const nodeR = evt.type === 'done' || evt.type === 'blocked' ? 6 :
+                              evt.type === 'commit' ? 5 : evt.type === 'error' ? 5 : 3.5;
+                const ec = eventColor[evt.type] || color;
+                return (
+                  <g key={ei} className="river-node"
+                    onMouseEnter={(e) => onTooltip({
+                      x: e.clientX, y: e.clientY,
+                      title: `${lane.id} · ${evt.type}`,
+                      rows: [
+                        ['Event', evt.label],
+                        ['Time', `-${maxT - evt.t}m ago`],
+                        ['Owner', lane.owner],
+                        ['Status', lane.status],
+                      ]
+                    })}
+                    onMouseLeave={() => onTooltip(null)}>
+                    {/* Glow */}
+                    <circle cx={ex} cy={y} r={nodeR + 4} fill={ec} fillOpacity={0.08} />
+                    {/* Node */}
+                    <circle cx={ex} cy={y} r={nodeR} fill={ec} fillOpacity={0.7}
+                            stroke={ec} strokeWidth={1} strokeOpacity={0.4} />
+                    {/* Pulsing ring for blocked/error */}
+                    {(evt.type === 'blocked' || evt.type === 'error') && (
+                      <circle cx={ex} cy={y} r={nodeR + 2} fill="none" stroke={ec} strokeWidth={1} strokeOpacity={0.3}>
+                        <animate attributeName="r" values={`${nodeR+2};${nodeR+8};${nodeR+2}`} dur="2s" repeatCount="indefinite" />
+                        <animate attributeName="stroke-opacity" values="0.3;0;0.3" dur="2s" repeatCount="indefinite" />
+                      </circle>
+                    )}
+                  </g>
+                );
+              })}
+
+              {/* Label */}
+              <text x={4} y={y + 4} className="river-lane-label" style={{fill:color,fontSize:'9px'}}>
+                {lane.id.replace(`${lane.owner}-`, '').slice(0, 18)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Git commits as diamonds on a separate row */}
+        <g>
+          <line x1={padding.left} y1={svgH - 30} x2={svgW - padding.right} y2={svgH - 30}
+                stroke="rgba(0,224,122,0.1)" strokeWidth={1} />
+          <text x={4} y={svgH - 26} className="river-label" style={{fill:'#00e07a'}}>GIT</text>
+          {commits.map((c, ci) => {
+            const cx = padding.left + c.time * timeScale;
+            const cy = svgH - 30;
+            return (
+              <g key={ci} className="river-node"
+                onMouseEnter={(e) => onTooltip({
+                  x: e.clientX, y: e.clientY,
+                  title: `Commit ${c.hash}`,
+                  rows: [['Message', c.msg], ['Author', c.author], ['Branch', c.branch], ['Time', `-${c.time}m`]]
+                })}
+                onMouseLeave={() => onTooltip(null)}>
+                <rect x={cx-5} y={cy-5} width={10} height={10}
+                      transform={`rotate(45 ${cx} ${cy})`}
+                      fill={ownerColor[c.author] || '#00e07a'} fillOpacity={0.6}
+                      stroke={ownerColor[c.author] || '#00e07a'} strokeWidth={1} strokeOpacity={0.3} />
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+});
+
+function Detail({ lane }) {
+  if (!lane) return (
+    <div className="detail">
+      <div className="section-title">Detail View</div>
+      <div className="detail-empty">Select a lane from the sidebar<br/>or hover events in the timeline</div>
+
+      <div className="section-title" style={{marginTop:20}}>Recent Commits</div>
+      {GIT_COMMITS.slice(0,5).map(c => (
+        <div className="commit-item" key={c.hash} style={{borderColor:ownerColor[c.author]}}>
+          <span className="commit-hash">{c.hash.slice(0,7)}</span>
+          <div className="commit-msg">{c.msg}</div>
+          <div className="commit-meta">{c.author} · {c.branch} · -{c.time}m</div>
+        </div>
+      ))}
+
+      <div className="section-title" style={{marginTop:16}}>Model Endpoints</div>
+      {ENDPOINTS.map(ep => (
+        <div className="endpoint-item" key={ep.id}>
+          <div className="endpoint-dot" style={{background:ep.ok?'var(--ok)':'var(--crit)',boxShadow:`0 0 4px ${ep.ok?'var(--ok)':'var(--crit)'}`}} />
+          <div style={{flex:1}}>
+            <div style={{fontWeight:600,color:ep.ok?'var(--text)':'var(--crit)'}}>{ep.id}</div>
+            <div style={{fontSize:'8px',color:'var(--muted)'}}>{ep.provider} · {ep.latency}ms{ep.models ? ` · ${ep.models} models` : ''}</div>
+          </div>
+        </div>
+      ))}
+
+      <div className="section-title" style={{marginTop:16}}>Active Alerts ({ALERTS.length})</div>
+      {ALERTS.map((a,i) => (
+        <div key={i} style={{
+          padding:'8px',margin:'4px 0',borderRadius:'4px',fontSize:'10px',
+          background:a.sev==='high'?'rgba(255,48,80,0.06)':'rgba(255,170,0,0.04)',
+          borderLeft:`2px solid ${a.sev==='high'?'var(--crit)':'var(--warn)'}`,
+          color:a.sev==='high'?'var(--crit)':'var(--warn)'
+        }}>{a.msg}</div>
+      ))}
+    </div>
+  );
+
+  const color = ownerColor[lane.owner];
+  return (
+    <div className="detail">
+      <div className="section-title" style={{color}}>
+        {lane.owner.toUpperCase()} / {lane.id.replace(`${lane.owner}-`,'')}
+      </div>
+      <div style={{display:'grid',gridTemplateColumns:'1fr 1fr',gap:8,marginBottom:12}}>
+        <div style={{background:'rgba(20,30,45,0.5)',borderRadius:6,padding:'10px',textAlign:'center'}}>
+          <div style={{fontSize:'8px',color:'var(--muted)',textTransform:'uppercase',letterSpacing:'0.1em'}}>Status</div>
+          <div style={{fontSize:'14px',fontWeight:700,color:statusColor[lane.status],marginTop:4}}>{lane.status.replace('_',' ').toUpperCase()}</div>
+        </div>
+        <div style={{background:'rgba(20,30,45,0.5)',borderRadius:6,padding:'10px',textAlign:'center'}}>
+          <div style={{fontSize:'8px',color:'var(--muted)',textTransform:'uppercase',letterSpacing:'0.1em'}}>Progress</div>
+          <div style={{fontSize:'14px',fontWeight:700,color,marginTop:4}}>{lane.tasks_done}/{lane.tasks_total}</div>
+        </div>
+        <div style={{background:'rgba(20,30,45,0.5)',borderRadius:6,padding:'10px',textAlign:'center'}}>
+          <div style={{fontSize:'8px',color:'var(--muted)',textTransform:'uppercase',letterSpacing:'0.1em'}}>Cost</div>
+          <div style={{fontSize:'14px',fontWeight:700,marginTop:4}}>${lane.cost.toFixed(2)}</div>
+        </div>
+        <div style={{background:'rgba(20,30,45,0.5)',borderRadius:6,padding:'10px',textAlign:'center'}}>
+          <div style={{fontSize:'8px',color:'var(--muted)',textTransform:'uppercase',letterSpacing:'0.1em'}}>Heartbeat</div>
+          <div style={{fontSize:'14px',fontWeight:700,color:lane.heartbeat_age>120?'var(--warn)':'inherit',marginTop:4}}>{lane.heartbeat_age}s</div>
+        </div>
+      </div>
+
+      <div className="section-title">Event Timeline</div>
+      {lane.events.map((evt, i) => (
+        <div key={i} style={{
+          display:'flex',gap:8,padding:'6px 0',borderBottom:'1px solid rgba(40,60,90,0.15)',fontSize:'10px',alignItems:'center'
+        }}>
+          <div style={{width:6,height:6,borderRadius:'50%',background:eventColor[evt.type],flexShrink:0,boxShadow:`0 0 4px ${eventColor[evt.type]}`}} />
+          <div style={{flex:1}}>
+            <span style={{color:eventColor[evt.type],fontWeight:600,textTransform:'uppercase',fontSize:'8px',letterSpacing:'0.05em'}}>{evt.type}</span>
+            <div style={{color:'var(--text)',marginTop:1}}>{evt.label}</div>
+          </div>
+          <span style={{color:'var(--muted)',fontFamily:'SF Mono, monospace',fontSize:'8px'}}>-{Math.max(0,35-evt.t)}m</span>
+        </div>
+      ))}
+
+      <div className="section-title" style={{marginTop:12}}>Related Commits</div>
+      {GIT_COMMITS.filter(c => c.author === lane.owner).slice(0,3).map(c => (
+        <div className="commit-item" key={c.hash} style={{borderColor:color}}>
+          <span className="commit-hash">{c.hash.slice(0,7)}</span>
+          <div className="commit-msg">{c.msg}</div>
+          <div className="commit-meta">{c.branch} · -{c.time}m</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Footer() {
+  const active = LANES.filter(l => l.status === 'in_progress').length;
+  const done = LANES.filter(l => l.status === 'done').length;
+  const blocked = LANES.filter(l => l.status === 'blocked').length;
+  return (
+    <div className="footer">
+      <div>AEGIS v1.0 · orxaq-ops · poc/dashboard-scifi-nexus-aegis-20260212</div>
+      <div style={{display:'flex',gap:16}}>
+        <span><span style={{color:'var(--ok)'}}>●</span> {done} done</span>
+        <span><span style={{color:'var(--accent)'}}>●</span> {active} active</span>
+        <span><span style={{color:'var(--crit)'}}>●</span> {blocked} blocked</span>
+        <span>Lanes: {LANES.length} · PRs: 22 · Branches: 103</span>
+      </div>
+    </div>
+  );
+}
+
+function Tooltip({ x, y, title, rows }) {
+  const style = {
+    left: Math.min(x + 12, window.innerWidth - 320),
+    top: Math.min(y + 12, window.innerHeight - 150),
+  };
+  return (
+    <div className="tooltip" style={style}>
+      <div className="tt-title">{title}</div>
+      {rows.map(([label, val], i) => (
+        <div className="tt-row" key={i}><span className="tt-label">{label}</span><span className="tt-val">{val}</span></div>
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/src/orxaq_autonomy/dashboard_nexus.html
+++ b/src/orxaq_autonomy/dashboard_nexus.html
@@ -1,0 +1,604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NEXUS — Swarm Command HUD</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%;overflow:hidden;background:#000;font-family:'SF Mono','Fira Code','Cascadia Code',monospace;color:#c0d8e8}
+canvas#bg{position:fixed;top:0;left:0;width:100%;height:100%;z-index:0}
+
+/* ── HUD Overlay ── */
+.hud{position:fixed;z-index:10;pointer-events:none}
+.hud *{pointer-events:auto}
+
+/* Top edge: status strip */
+.hud-top{top:0;left:0;right:0;display:flex;justify-content:space-between;align-items:center;padding:8px 20px;background:linear-gradient(180deg,rgba(0,20,40,0.85) 0%,transparent 100%)}
+.hud-top .logo{font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#4dd8e8}
+.hud-top .status-cluster{display:flex;gap:16px;font-size:10px}
+.hud-top .st{display:flex;align-items:center;gap:5px}
+.hud-top .st .dot{width:6px;height:6px;border-radius:50%;animation:blink 2s ease-in-out infinite}
+.dot.green{background:#00e87b;box-shadow:0 0 6px #00e87b}.dot.amber{background:#e8a800;box-shadow:0 0 6px #e8a800}.dot.red{background:#e83030;box-shadow:0 0 6px #e83030}
+@keyframes blink{0%,100%{opacity:1}50%{opacity:0.5}}
+
+/* Bottom edge: telemetry strip */
+.hud-bottom{bottom:0;left:0;right:0;display:flex;justify-content:space-between;padding:8px 20px;background:linear-gradient(0deg,rgba(0,20,40,0.85) 0%,transparent 100%);font-size:10px}
+.telem-group{display:flex;gap:20px}
+.telem{display:flex;flex-direction:column;align-items:center;gap:2px}
+.telem-label{font-size:8px;color:#4a7a8a;text-transform:uppercase;letter-spacing:0.12em}
+.telem-val{font-size:14px;font-weight:700;color:#4dd8e8}
+.telem-val.warn{color:#e8a800}
+.telem-val.crit{color:#e83030}
+
+/* Left edge: lane status */
+.hud-left{top:50px;left:0;bottom:50px;width:200px;padding:12px;display:flex;flex-direction:column;gap:2px;overflow-y:auto}
+.hud-left::-webkit-scrollbar{width:2px}
+.hud-left::-webkit-scrollbar-thumb{background:#1a3a4a}
+.lane-title{font-size:8px;color:#4a7a8a;text-transform:uppercase;letter-spacing:0.15em;margin-bottom:4px;padding-bottom:4px;border-bottom:1px solid #0a2a3a}
+.lane{display:flex;align-items:center;gap:6px;padding:4px 6px;border-radius:3px;font-size:9px;cursor:pointer;transition:background 0.15s;border-left:2px solid transparent}
+.lane:hover{background:rgba(77,216,232,0.08)}
+.lane.active{border-left-color:#4dd8e8;background:rgba(77,216,232,0.05)}
+.lane .l-dot{width:5px;height:5px;border-radius:50%;flex-shrink:0}
+.lane .l-name{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#7ab0c0}
+.lane .l-stat{font-size:8px;color:#4a7a8a}
+
+/* Right edge: event feed */
+.hud-right{top:50px;right:0;bottom:50px;width:300px;padding:12px;display:flex;flex-direction:column}
+.feed-title{font-size:8px;color:#4a7a8a;text-transform:uppercase;letter-spacing:0.15em;margin-bottom:4px;padding-bottom:4px;border-bottom:1px solid #0a2a3a}
+.feed{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:1px}
+.feed::-webkit-scrollbar{width:2px}
+.feed::-webkit-scrollbar-thumb{background:#1a3a4a}
+.evt{padding:4px 6px;font-size:9px;border-left:2px solid;animation:fadeSlide 0.3s ease-out}
+.evt.task_selected{border-color:#4dd8e8;color:#7ab0c0}
+.evt.task_done{border-color:#00e87b;color:#60c090}
+.evt.task_blocked{border-color:#e83030;color:#c06060}
+.evt.routing_decision{border-color:#8a60d8;color:#a080c0}
+.evt.agent_error{border-color:#e8a800;color:#c0a060}
+.evt.prompt{border-color:#2a5a7a;color:#5a8a9a}
+.evt .evt-time{font-size:7px;color:#3a6a7a}
+.evt .evt-body{margin-top:1px}
+@keyframes fadeSlide{from{opacity:0;transform:translateX(20px)}to{opacity:1;transform:translateX(0)}}
+
+/* Center: alert zone (only visible when alerts exist) */
+.hud-center{top:50%;left:50%;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:8px;opacity:0;transition:opacity 0.5s}
+.hud-center.active{opacity:1}
+.center-alert{padding:8px 20px;border-radius:4px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.08em;animation:alertPulse 3s ease-in-out infinite;cursor:pointer}
+.center-alert.high{background:rgba(232,48,48,0.15);border:1px solid rgba(232,48,48,0.4);color:#e83030}
+.center-alert.medium{background:rgba(232,168,0,0.1);border:1px solid rgba(232,168,0,0.3);color:#e8a800}
+@keyframes alertPulse{0%,100%{box-shadow:0 0 10px transparent}50%{box-shadow:0 0 20px rgba(232,48,48,0.2)}}
+
+/* Detail overlay */
+#detail-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,10,20,0.7);z-index:100;display:none;align-items:center;justify-content:center;backdrop-filter:blur(4px)}
+#detail-overlay.open{display:flex}
+#detail-panel{background:rgba(0,20,35,0.95);border:1px solid #1a3a5a;border-radius:8px;padding:24px;max-width:500px;width:90%;max-height:80vh;overflow-y:auto;position:relative}
+#detail-panel .close{position:absolute;top:8px;right:12px;background:none;border:none;color:#4a7a8a;font-size:18px;cursor:pointer}
+#detail-panel h3{font-size:12px;color:#4dd8e8;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:12px}
+.d-row{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid #0a1a2a;font-size:11px}
+.d-label{color:#4a7a8a}.d-val{color:#c0d8e8;font-weight:600}
+.d-val.green{color:#00e87b}.d-val.amber{color:#e8a800}.d-val.red{color:#e83030}.d-val.cyan{color:#4dd8e8}
+.d-bar{height:4px;background:#0a1a2a;border-radius:2px;margin-top:4px;overflow:hidden}
+.d-bar-fill{height:100%;border-radius:2px;transition:width 0.6s ease}
+.d-section{font-size:9px;color:#4a7a8a;text-transform:uppercase;letter-spacing:0.12em;margin:16px 0 8px;padding-top:8px;border-top:1px solid #0a2a3a}
+</style>
+</head>
+<body>
+<canvas id="bg"></canvas>
+
+<!-- Top HUD -->
+<div class="hud hud-top">
+  <div class="logo">⬡ NEXUS — Swarm Command</div>
+  <div class="status-cluster">
+    <div class="st"><span class="dot green"></span> Supervisor</div>
+    <div class="st"><span class="dot" id="runner-dot"></span> <span id="runner-label">Runner</span></div>
+    <div class="st"><span class="dot" id="heartbeat-dot"></span> <span id="heartbeat-label">Heartbeat</span></div>
+    <div class="st" style="color:#4a7a8a" id="clock"></div>
+  </div>
+</div>
+
+<!-- Bottom Telemetry -->
+<div class="hud hud-bottom">
+  <div class="telem-group">
+    <div class="telem"><span class="telem-label">Tasks Done</span><span class="telem-val" id="t-done">0</span></div>
+    <div class="telem"><span class="telem-label">In Progress</span><span class="telem-val" id="t-prog">0</span></div>
+    <div class="telem"><span class="telem-label">Pending</span><span class="telem-val" id="t-pend">0</span></div>
+    <div class="telem"><span class="telem-label">Blocked</span><span class="telem-val" id="t-block">0</span></div>
+  </div>
+  <div class="telem-group">
+    <div class="telem"><span class="telem-label">Cost (USD)</span><span class="telem-val" id="t-cost">$0.00</span></div>
+    <div class="telem"><span class="telem-label">Tokens</span><span class="telem-val" id="t-tokens">0</span></div>
+    <div class="telem"><span class="telem-label">Pass Rate</span><span class="telem-val" id="t-pass">0%</span></div>
+    <div class="telem"><span class="telem-label">Latency</span><span class="telem-val" id="t-latency">0s</span></div>
+  </div>
+  <div class="telem-group">
+    <div class="telem"><span class="telem-label">Lanes Active</span><span class="telem-val" id="t-lanes">0</span></div>
+    <div class="telem"><span class="telem-label">Responses</span><span class="telem-val" id="t-responses">0</span></div>
+    <div class="telem"><span class="telem-label">Budget Left</span><span class="telem-val" id="t-budget">$0</span></div>
+    <div class="telem"><span class="telem-label">Uptime</span><span class="telem-val" id="t-uptime">0h</span></div>
+  </div>
+</div>
+
+<!-- Left: Lane Status -->
+<div class="hud hud-left">
+  <div class="lane-title">Lane Status</div>
+  <div id="lane-list"></div>
+</div>
+
+<!-- Right: Event Feed -->
+<div class="hud hud-right">
+  <div class="feed-title">Event Stream <span id="evt-count" style="color:#4dd8e8"></span></div>
+  <div class="feed" id="event-feed"></div>
+</div>
+
+<!-- Center: Alerts -->
+<div class="hud hud-center" id="alert-zone"></div>
+
+<!-- Detail Overlay -->
+<div id="detail-overlay" onclick="if(event.target===this)closeDetail()">
+  <div id="detail-panel">
+    <button class="close" onclick="closeDetail()">×</button>
+    <div id="detail-body"></div>
+  </div>
+</div>
+
+<script>
+// ══════════════════════════════════════════════════════════════════
+// DATA — Simulated from real orxaq-ops artifact structures
+// ══════════════════════════════════════════════════════════════════
+const SWARM = {
+  status: {
+    supervisor_running: true, runner_running: true,
+    heartbeat_stale: false, heartbeat_age_sec: 5,
+  },
+  state_counts: { done: 19, in_progress: 3, pending: 4, blocked: 1, unknown: 0 },
+  budget: { daily_cap: 100.0, daily_spend: 1.68, remaining: 98.32 },
+  metrics: {
+    responses_total: 445,
+    cost_usd_total: 1.6818,
+    tokens_total: 1055013,
+    first_time_pass_rate: 0.481,
+    acceptance_pass_rate: 0.524,
+    latency_sec_avg: 90.26,
+    token_rate_per_minute: 1575.9,
+    routing_routellm_rate: 0.438,
+    routing_fallback_rate: 0.456,
+  },
+  lanes: [
+    { id:'codex-governance', owner:'codex', status:'done', tasks_done:4, tasks_total:4, cycles:12, cost:0.22, last_task:'governance-e2e', last_event:'Governance sweep complete', heartbeat_age:3 },
+    { id:'codex-routellm-npv', owner:'codex', status:'in_progress', tasks_done:2, tasks_total:5, cycles:38, cost:0.45, last_task:'routellm-npv-analysis', last_event:'NPV calculation cycle 38', heartbeat_age:8 },
+    { id:'codex-dashboard-todo', owner:'codex', status:'pending', tasks_done:0, tasks_total:1, cycles:8, cost:0.12, last_task:'todo-metrics-fix', last_event:'Retry cooldown 10s', heartbeat_age:5 },
+    { id:'codex-dashboard-ui', owner:'codex', status:'in_progress', tasks_done:1, tasks_total:3, cycles:15, cost:0.18, last_task:'accessibility-audit', last_event:'ARIA labels pass', heartbeat_age:2 },
+    { id:'codex-rpa-security', owner:'codex', status:'done', tasks_done:3, tasks_total:3, cycles:22, cost:0.31, last_task:'rpa-xss-hardening', last_event:'All XSS vectors patched', heartbeat_age:120 },
+    { id:'gemini-skin-regression', owner:'gemini', status:'blocked', tasks_done:2, tasks_total:4, cycles:9, cost:0.08, last_task:'skin-parity-check', last_event:'Blocked: merge conflict in skins.py', heartbeat_age:45 },
+    { id:'gemini-rln-tests', owner:'gemini', status:'done', tasks_done:5, tasks_total:5, cycles:30, cost:0.15, last_task:'semantic-validation', last_event:'All semantic tests green', heartbeat_age:200 },
+    { id:'claude-release-audit', owner:'claude', status:'in_progress', tasks_done:1, tasks_total:2, cycles:6, cost:0.09, last_task:'phase32-release-check', last_event:'Scanning signoff log integrity', heartbeat_age:15 },
+    { id:'claude-collab-health', owner:'claude', status:'done', tasks_done:2, tasks_total:2, cycles:4, cost:0.03, last_task:'collab-health-monitor', last_event:'Health report generated', heartbeat_age:300 },
+  ],
+  events: [
+    { ts:'12:55:37', type:'task_selected', lane:'codex-routellm-npv', body:'Selected task routellm-npv-analysis cycle 38' },
+    { ts:'12:55:27', type:'agent_error', lane:'codex-dashboard-todo', body:'Codex: unexpected argument --ask-for-approval' },
+    { ts:'12:55:24', type:'routing_decision', lane:'codex-routellm-npv', body:'Router → gpt-5.3-codex (static_fallback)' },
+    { ts:'12:54:58', type:'task_done', lane:'codex-governance', body:'Governance e2e sweep completed ✓' },
+    { ts:'12:54:45', type:'prompt', lane:'claude-release-audit', body:'Initiated phase32 release integrity scan' },
+    { ts:'12:54:30', type:'task_blocked', lane:'gemini-skin-regression', body:'Merge conflict in cockpit/skins.py — manual resolution needed' },
+    { ts:'12:54:12', type:'task_done', lane:'codex-rpa-security', body:'XSS vector patching complete, 3/3 tasks done' },
+    { ts:'12:53:58', type:'routing_decision', lane:'codex-dashboard-ui', body:'RouteLLM selected liquid/lfm2.5 (latency: 2.4ms)' },
+    { ts:'12:53:40', type:'task_selected', lane:'claude-release-audit', body:'Claiming phase32-release-check' },
+    { ts:'12:53:20', type:'task_done', lane:'gemini-rln-tests', body:'Semantic validation suite green ✓' },
+    { ts:'12:52:55', type:'prompt', lane:'codex-routellm-npv', body:'NPV sensitivity analysis: varying discount rate 3-12%' },
+    { ts:'12:52:30', type:'routing_decision', lane:'gemini-skin-regression', body:'Router → gemini-2.5-flash (routellm selected)' },
+    { ts:'12:52:10', type:'task_done', lane:'claude-collab-health', body:'Collaboration health report written to artifacts/' },
+    { ts:'12:51:45', type:'task_selected', lane:'codex-dashboard-ui', body:'Starting accessibility audit task 2/3' },
+    { ts:'12:51:20', type:'agent_error', lane:'codex-dashboard-todo', body:'Retry #3: git index.lock conflict (auto-resolved)' },
+  ],
+  alerts: [
+    { id:1, sev:'high', type:'BLOCKED LANE', msg:'gemini-skin-regression: merge conflict in cockpit/skins.py', lane:'gemini-skin-regression' },
+    { id:2, sev:'medium', type:'RETRY STORM', msg:'codex-dashboard-todo: 3 retries, 8 deadlock recoveries', lane:'codex-dashboard-todo' },
+    { id:3, sev:'medium', type:'STALE HEARTBEAT', msg:'claude-collab-health: 300s since last heartbeat', lane:'claude-collab-health' },
+  ],
+  git: {
+    branches_local: 63, branches_remote: 40,
+    open_prs: 22, t1_prs: 22, t1_ratio: 1.0,
+    recent_commits: [
+      { hash:'a3f2c1d', msg:'fix(dashboard): ARIA labels for metric cards', author:'codex', ago:'2m' },
+      { hash:'8b1e4f7', msg:'test(rln): add semantic regression suite', author:'gemini', ago:'5m' },
+      { hash:'c5d9a2b', msg:'chore(ops): restore swarm runtime v1', author:'codex', ago:'12m' },
+      { hash:'f7e3b08', msg:'feat(rpa): XSS vector hardening', author:'codex', ago:'18m' },
+      { hash:'2a8c1d5', msg:'docs(governance): breakglass policy v2.1', author:'codex', ago:'25m' },
+    ]
+  },
+  connectivity: {
+    endpoints: [
+      { id:'lmstudio-node-1', ok:true, latency:2.4, models:11 },
+      { id:'claude-primary', ok:false, latency:101.4, error:'401 auth' },
+      { id:'openai-codex', ok:true, latency:45.2, models:3 },
+    ]
+  }
+};
+
+// ══════════════════════════════════════════════════════════════════
+// CANVAS GAME ENGINE — 60fps render loop
+// ══════════════════════════════════════════════════════════════════
+const canvas = document.getElementById('bg');
+const ctx = canvas.getContext('2d');
+const dpr = window.devicePixelRatio || 1;
+let W, H, cx, cy;
+
+function resize() {
+  W = window.innerWidth; H = window.innerHeight;
+  canvas.width = W * dpr; canvas.height = H * dpr;
+  canvas.style.width = W + 'px'; canvas.style.height = H + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  cx = W / 2; cy = H / 2;
+}
+resize();
+window.addEventListener('resize', resize);
+
+// ── Particles ──
+class Particle {
+  constructor(lane, type) {
+    this.lane = lane;
+    this.type = type; // 'task','event','error'
+    const angle = Math.random() * Math.PI * 2;
+    const dist = 80 + Math.random() * 180;
+    this.x = cx + Math.cos(angle) * dist;
+    this.y = cy + Math.sin(angle) * dist;
+    this.vx = (Math.random() - 0.5) * 0.3;
+    this.vy = (Math.random() - 0.5) * 0.3;
+    this.life = 1;
+    this.decay = 0.001 + Math.random() * 0.003;
+    this.size = type === 'error' ? 3 : type === 'event' ? 2 : 1.5;
+    this.color = type === 'error' ? [232,48,48] : type === 'event' ? [77,216,232] : [0,232,123];
+  }
+  update() {
+    this.x += this.vx;
+    this.y += this.vy;
+    this.life -= this.decay;
+    // gentle drift toward center
+    this.vx += (cx - this.x) * 0.00003;
+    this.vy += (cy - this.y) * 0.00003;
+  }
+  draw(ctx) {
+    if (this.life <= 0) return;
+    const [r,g,b] = this.color;
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.size * this.life, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(${r},${g},${b},${this.life * 0.6})`;
+    ctx.fill();
+    // glow
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.size * 3 * this.life, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(${r},${g},${b},${this.life * 0.08})`;
+    ctx.fill();
+  }
+}
+
+let particles = [];
+function spawnParticles() {
+  const types = ['task','task','task','event','event','error'];
+  particles.push(new Particle(null, types[Math.floor(Math.random() * types.length)]));
+}
+
+// ── Radar Sweep ──
+let radarAngle = 0;
+const radarSpeed = 0.008;
+
+function drawRadar() {
+  const r = Math.min(W, H) * 0.28;
+  // ring
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.strokeStyle = 'rgba(77,216,232,0.06)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+  // inner ring
+  ctx.beginPath();
+  ctx.arc(cx, cy, r * 0.6, 0, Math.PI * 2);
+  ctx.stroke();
+  // inner-inner
+  ctx.beginPath();
+  ctx.arc(cx, cy, r * 0.3, 0, Math.PI * 2);
+  ctx.stroke();
+  // crosshairs
+  ctx.strokeStyle = 'rgba(77,216,232,0.04)';
+  ctx.beginPath();
+  ctx.moveTo(cx - r, cy); ctx.lineTo(cx + r, cy);
+  ctx.moveTo(cx, cy - r); ctx.lineTo(cx, cy + r);
+  ctx.stroke();
+
+  // sweep
+  radarAngle += radarSpeed;
+  const grad = ctx.createConicalGradient ? null : null; // fallback
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.arc(cx, cy, r, radarAngle - 0.5, radarAngle);
+  ctx.closePath();
+  const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+  g.addColorStop(0, 'rgba(77,216,232,0.0)');
+  g.addColorStop(0.4, 'rgba(77,216,232,0.04)');
+  g.addColorStop(1, 'rgba(77,216,232,0.12)');
+  ctx.fillStyle = g;
+  ctx.fill();
+
+  // sweep line
+  const sx = cx + Math.cos(radarAngle) * r;
+  const sy = cy + Math.sin(radarAngle) * r;
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.lineTo(sx, sy);
+  ctx.strokeStyle = 'rgba(77,216,232,0.25)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  // lane blips on radar
+  SWARM.lanes.forEach((lane, i) => {
+    const a = (i / SWARM.lanes.length) * Math.PI * 2 - Math.PI / 2;
+    const d = r * 0.4 + (lane.cycles / 40) * r * 0.4;
+    const bx = cx + Math.cos(a) * Math.min(d, r * 0.9);
+    const by = cy + Math.sin(a) * Math.min(d, r * 0.9);
+    const color = lane.status === 'done' ? 'rgba(0,232,123,X)' :
+                  lane.status === 'in_progress' ? 'rgba(77,216,232,X)' :
+                  lane.status === 'blocked' ? 'rgba(232,48,48,X)' :
+                  'rgba(232,168,0,X)';
+    // blip glow
+    const proximity = Math.abs(((radarAngle % (Math.PI*2)) - (a % (Math.PI*2) + Math.PI*2) % (Math.PI*2)));
+    const intensity = proximity < 0.6 ? (0.6 - proximity) / 0.6 : 0;
+    const alpha = 0.3 + intensity * 0.7;
+    ctx.beginPath();
+    ctx.arc(bx, by, 3 + intensity * 3, 0, Math.PI * 2);
+    ctx.fillStyle = color.replace('X', alpha.toFixed(2));
+    ctx.fill();
+    // outer ring on active
+    if (lane.status === 'in_progress') {
+      ctx.beginPath();
+      ctx.arc(bx, by, 8 + Math.sin(Date.now()/500) * 2, 0, Math.PI * 2);
+      ctx.strokeStyle = color.replace('X', '0.2');
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+  });
+}
+
+// ── Grid / Scanlines ──
+function drawGrid() {
+  ctx.strokeStyle = 'rgba(77,216,232,0.015)';
+  ctx.lineWidth = 1;
+  const step = 40;
+  for (let x = 0; x < W; x += step) {
+    ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+  }
+  for (let y = 0; y < H; y += step) {
+    ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+  }
+  // scanlines
+  ctx.fillStyle = 'rgba(0,0,0,0.03)';
+  for (let y = 0; y < H; y += 3) {
+    ctx.fillRect(0, y, W, 1);
+  }
+}
+
+// ── Budget Arc ──
+function drawBudgetArc() {
+  const r = Math.min(W, H) * 0.28 + 20;
+  const startA = -Math.PI * 0.75;
+  const endA = -Math.PI * 0.25;
+  const spent = SWARM.budget.daily_spend / SWARM.budget.daily_cap;
+  const spentAngle = startA + spent * (endA - startA);
+  // background arc
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, startA, endA);
+  ctx.strokeStyle = 'rgba(77,216,232,0.06)';
+  ctx.lineWidth = 3;
+  ctx.stroke();
+  // spent arc
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, startA, spentAngle);
+  ctx.strokeStyle = spent > 0.8 ? 'rgba(232,48,48,0.5)' : spent > 0.5 ? 'rgba(232,168,0,0.5)' : 'rgba(0,232,123,0.4)';
+  ctx.lineWidth = 3;
+  ctx.stroke();
+  // label
+  ctx.font = '8px monospace';
+  ctx.fillStyle = 'rgba(77,216,232,0.3)';
+  ctx.textAlign = 'center';
+  ctx.fillText('BUDGET ' + (spent * 100).toFixed(1) + '%', cx, cy - r - 8);
+}
+
+// ── Commit Pulse Ring ──
+let commitPulses = [];
+function triggerCommitPulse() {
+  commitPulses.push({ r: 0, alpha: 0.3 });
+}
+function drawCommitPulses() {
+  commitPulses = commitPulses.filter(p => p.alpha > 0.01);
+  commitPulses.forEach(p => {
+    p.r += 1.5;
+    p.alpha *= 0.985;
+    ctx.beginPath();
+    ctx.arc(cx, cy, p.r, 0, Math.PI * 2);
+    ctx.strokeStyle = `rgba(0,232,123,${p.alpha})`;
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  });
+}
+
+// ── Main Render Loop ──
+let frame = 0;
+function render() {
+  ctx.clearRect(0, 0, W, H);
+
+  // background gradient
+  const bg = ctx.createRadialGradient(cx, cy, 0, cx, cy, Math.max(W,H)*0.7);
+  bg.addColorStop(0, '#020a14');
+  bg.addColorStop(1, '#000408');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
+
+  drawGrid();
+  drawRadar();
+  drawBudgetArc();
+  drawCommitPulses();
+
+  // spawn particles periodically
+  if (frame % 8 === 0) spawnParticles();
+  particles = particles.filter(p => p.life > 0);
+  particles.forEach(p => { p.update(); p.draw(ctx); });
+
+  // periodic commit pulse
+  if (frame % 300 === 0) triggerCommitPulse();
+
+  frame++;
+  requestAnimationFrame(render);
+}
+render();
+
+// ══════════════════════════════════════════════════════════════════
+// HUD DOM — Populate from data
+// ══════════════════════════════════════════════════════════════════
+
+// Clock
+setInterval(() => {
+  document.getElementById('clock').textContent = new Date().toISOString().slice(11, 19) + 'Z';
+}, 1000);
+
+// Runner/heartbeat dots
+const rd = document.getElementById('runner-dot');
+const hd = document.getElementById('heartbeat-dot');
+rd.className = 'dot ' + (SWARM.status.runner_running ? 'green' : 'red');
+hd.className = 'dot ' + (SWARM.status.heartbeat_stale ? 'red' : 'green');
+
+// Telemetry
+document.getElementById('t-done').textContent = SWARM.state_counts.done;
+document.getElementById('t-prog').textContent = SWARM.state_counts.in_progress;
+document.getElementById('t-pend').textContent = SWARM.state_counts.pending;
+const tb = document.getElementById('t-block');
+tb.textContent = SWARM.state_counts.blocked;
+if (SWARM.state_counts.blocked > 0) tb.className = 'telem-val crit';
+
+document.getElementById('t-cost').textContent = '$' + SWARM.metrics.cost_usd_total.toFixed(2);
+document.getElementById('t-tokens').textContent = (SWARM.metrics.tokens_total / 1000).toFixed(0) + 'K';
+const tp = document.getElementById('t-pass');
+tp.textContent = (SWARM.metrics.first_time_pass_rate * 100).toFixed(0) + '%';
+if (SWARM.metrics.first_time_pass_rate < 0.5) tp.className = 'telem-val warn';
+document.getElementById('t-latency').textContent = SWARM.metrics.latency_sec_avg.toFixed(0) + 's';
+document.getElementById('t-lanes').textContent = SWARM.lanes.filter(l => l.status === 'in_progress').length + '/' + SWARM.lanes.length;
+document.getElementById('t-responses').textContent = SWARM.metrics.responses_total;
+document.getElementById('t-budget').textContent = '$' + SWARM.budget.remaining.toFixed(0);
+document.getElementById('t-uptime').textContent = '2.4h';
+
+// Lanes
+const laneList = document.getElementById('lane-list');
+SWARM.lanes.forEach(lane => {
+  const div = document.createElement('div');
+  div.className = 'lane' + (lane.status === 'in_progress' ? ' active' : '');
+  const dotColor = lane.status === 'done' ? '#00e87b' : lane.status === 'in_progress' ? '#4dd8e8' : lane.status === 'blocked' ? '#e83030' : '#e8a800';
+  div.innerHTML = `<span class="l-dot" style="background:${dotColor};box-shadow:0 0 4px ${dotColor}"></span><span class="l-name">${lane.id}</span><span class="l-stat">${lane.tasks_done}/${lane.tasks_total}</span>`;
+  div.onclick = () => showLaneDetail(lane);
+  laneList.appendChild(div);
+});
+
+// Events
+const feed = document.getElementById('event-feed');
+document.getElementById('evt-count').textContent = `[${SWARM.events.length}]`;
+SWARM.events.forEach(evt => {
+  const div = document.createElement('div');
+  div.className = 'evt ' + evt.type;
+  div.innerHTML = `<div class="evt-time">${evt.ts} · ${evt.lane}</div><div class="evt-body">${evt.body}</div>`;
+  feed.appendChild(div);
+});
+
+// Alerts
+const alertZone = document.getElementById('alert-zone');
+if (SWARM.alerts.length > 0) {
+  alertZone.classList.add('active');
+  SWARM.alerts.forEach(a => {
+    const div = document.createElement('div');
+    div.className = 'center-alert ' + a.sev;
+    div.textContent = `⚠ ${a.type}: ${a.msg}`;
+    div.onclick = () => {
+      const lane = SWARM.lanes.find(l => l.id === a.lane);
+      if (lane) showLaneDetail(lane);
+    };
+    alertZone.appendChild(div);
+  });
+}
+
+// ══════════════════════════════════════════════════════════════════
+// DETAIL PANEL
+// ══════════════════════════════════════════════════════════════════
+function closeDetail() { document.getElementById('detail-overlay').classList.remove('open'); }
+
+function showLaneDetail(lane) {
+  const overlay = document.getElementById('detail-overlay');
+  const body = document.getElementById('detail-body');
+  const ownerColor = lane.owner === 'codex' ? 'cyan' : lane.owner === 'gemini' ? 'amber' : 'green';
+  const statusColor = lane.status === 'done' ? 'green' : lane.status === 'in_progress' ? 'cyan' : lane.status === 'blocked' ? 'red' : 'amber';
+
+  let html = `<h3>⬡ ${lane.id}</h3>`;
+  html += `<div class="d-row"><span class="d-label">Owner</span><span class="d-val ${ownerColor}">${lane.owner.toUpperCase()}</span></div>`;
+  html += `<div class="d-row"><span class="d-label">Status</span><span class="d-val ${statusColor}">${lane.status.toUpperCase()}</span></div>`;
+  html += `<div class="d-row"><span class="d-label">Progress</span><span class="d-val">${lane.tasks_done} / ${lane.tasks_total} tasks</span></div>`;
+  html += `<div class="d-bar"><div class="d-bar-fill" style="width:${(lane.tasks_done/lane.tasks_total*100)}%;background:${lane.status==='done'?'#00e87b':lane.status==='blocked'?'#e83030':'#4dd8e8'}"></div></div>`;
+  html += `<div class="d-row"><span class="d-label">Cycles</span><span class="d-val">${lane.cycles}</span></div>`;
+  html += `<div class="d-row"><span class="d-label">Cost</span><span class="d-val">$${lane.cost.toFixed(2)}</span></div>`;
+  html += `<div class="d-row"><span class="d-label">Heartbeat</span><span class="d-val ${lane.heartbeat_age > 120 ? 'amber' : ''}">${lane.heartbeat_age}s ago</span></div>`;
+  html += `<div class="d-row"><span class="d-label">Last Task</span><span class="d-val">${lane.last_task}</span></div>`;
+
+  html += `<div class="d-section">Latest Activity</div>`;
+  html += `<div style="font-size:10px;color:#7ab0c0;padding:8px;background:rgba(77,216,232,0.03);border-radius:4px;border-left:2px solid #1a3a5a">${lane.last_event}</div>`;
+
+  // Related events
+  const relEvents = SWARM.events.filter(e => e.lane === lane.id).slice(0, 5);
+  if (relEvents.length) {
+    html += `<div class="d-section">Event History</div>`;
+    relEvents.forEach(e => {
+      const c = e.type === 'task_done' ? '#00e87b' : e.type === 'agent_error' || e.type === 'task_blocked' ? '#e83030' : '#4a7a8a';
+      html += `<div style="font-size:9px;padding:3px 0;border-bottom:1px solid #0a1a2a"><span style="color:#3a6a7a">${e.ts}</span> <span style="color:${c}">${e.body}</span></div>`;
+    });
+  }
+
+  // Related alerts
+  const relAlerts = SWARM.alerts.filter(a => a.lane === lane.id);
+  if (relAlerts.length) {
+    html += `<div class="d-section">Active Alerts</div>`;
+    relAlerts.forEach(a => {
+      const c = a.sev === 'high' ? '#e83030' : '#e8a800';
+      html += `<div style="padding:6px 8px;margin:4px 0;border-radius:4px;background:${a.sev==='high'?'rgba(232,48,48,0.08)':'rgba(232,168,0,0.06)'};border-left:2px solid ${c};font-size:10px;color:${c}">${a.type}: ${a.msg}</div>`;
+    });
+  }
+
+  // Git activity for this lane
+  const relCommits = SWARM.git.recent_commits.filter(c => c.author === lane.owner).slice(0, 3);
+  if (relCommits.length) {
+    html += `<div class="d-section">Recent Commits (${lane.owner})</div>`;
+    relCommits.forEach(c => {
+      html += `<div style="font-size:9px;padding:3px 0;border-bottom:1px solid #0a1a2a"><span style="color:#4dd8e8">${c.hash.slice(0,7)}</span> <span style="color:#7ab0c0">${c.msg}</span> <span style="color:#3a6a7a">${c.ago}</span></div>`;
+    });
+  }
+
+  body.innerHTML = html;
+  overlay.classList.add('open');
+}
+
+// ── Keyboard: Escape to close ──
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeDetail();
+});
+
+// ── Simulated live activity ──
+let simTick = 0;
+setInterval(() => {
+  simTick++;
+  // rotate heartbeat ages
+  SWARM.lanes.forEach(l => {
+    if (l.status === 'in_progress') l.heartbeat_age = Math.max(1, (l.heartbeat_age + 1) % 30);
+  });
+  // occasional commit pulse
+  if (simTick % 15 === 0) triggerCommitPulse();
+  // particle burst for events
+  if (simTick % 10 === 0) {
+    for (let i = 0; i < 5; i++) particles.push(new Particle(null, 'event'));
+  }
+}, 1000);
+</script>
+</body>
+</html>

--- a/src/orxaq_autonomy/dashboard_v2.py
+++ b/src/orxaq_autonomy/dashboard_v2.py
@@ -1,0 +1,785 @@
+"""Production swarm command dashboard — data layer and HTTP handler.
+
+Reads live artifacts from the autonomy runtime (health, lanes, heartbeats,
+conversations, response metrics, git state) and serves them as JSON APIs
+alongside an interactive HTML frontend.
+
+Zero external dependencies beyond the Python standard library.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib import parse as urllib_parse
+
+from . import dashboard_actions
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_json(path: Path) -> dict[str, Any] | list[Any]:
+    """Read a JSON file, returning {} on any error."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, (dict, list)) else {}
+
+
+def _read_json_dict(path: Path) -> dict[str, Any]:
+    result = _read_json(path)
+    return result if isinstance(result, dict) else {}
+
+
+def _read_ndjson(path: Path, *, tail: int = 200) -> list[dict[str, Any]]:
+    """Read last *tail* lines of an NDJSON file."""
+    if not path.exists():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return []
+    lines = [l.strip() for l in raw.splitlines() if l.strip()]
+    if tail > 0:
+        lines = lines[-tail:]
+    out: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                out.append(obj)
+        except Exception:
+            continue
+    return out
+
+
+def _safe_int(val: Any, default: int = 0) -> int:
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(val: Any, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── Lane Discovery ───────────────────────────────────────────────────────────
+
+def discover_lanes(artifacts_dir: Path) -> list[dict[str, Any]]:
+    """Discover all lanes from artifacts/autonomy/lanes/ directory."""
+    lanes_dir = artifacts_dir / "autonomy" / "lanes"
+    if not lanes_dir.is_dir():
+        return []
+
+    lanes: list[dict[str, Any]] = []
+    for lane_dir in sorted(lanes_dir.iterdir()):
+        if not lane_dir.is_dir():
+            continue
+        lane = _read_lane(lane_dir)
+        if lane:
+            lanes.append(lane)
+    return lanes
+
+
+def _read_lane(lane_dir: Path) -> dict[str, Any] | None:
+    """Read a single lane's state from its directory."""
+    lane_id = lane_dir.name
+    config = _read_json_dict(lane_dir / "lane.json")
+    state = _read_json_dict(lane_dir / "state.json")
+    heartbeat = _read_json_dict(lane_dir / "heartbeat.json")
+    metrics_summary = _read_json_dict(lane_dir / "response_metrics_summary.json")
+
+    owner = str(config.get("owner", "unknown"))
+
+    # Derive status from state.json tasks
+    task_counts = {"pending": 0, "in_progress": 0, "done": 0, "blocked": 0}
+    tasks: list[dict[str, Any]] = []
+    for task_id, task_data in state.items():
+        if not isinstance(task_data, dict):
+            continue
+        status = str(task_data.get("status", "unknown")).lower()
+        if status in task_counts:
+            task_counts[status] += 1
+        tasks.append({
+            "task_id": task_id,
+            "status": status,
+            "attempts": _safe_int(task_data.get("attempts", 0)),
+            "deadlock_recoveries": _safe_int(task_data.get("deadlock_recoveries", 0)),
+            "last_update": str(task_data.get("last_update", "")),
+            "last_summary": str(task_data.get("last_summary", ""))[:200],
+            "last_error": str(task_data.get("last_error", ""))[:200],
+            "owner": str(task_data.get("owner", owner)),
+        })
+
+    # Determine overall lane status
+    if task_counts["blocked"] > 0:
+        lane_status = "blocked"
+    elif task_counts["in_progress"] > 0:
+        lane_status = "in_progress"
+    elif task_counts["pending"] > 0:
+        lane_status = "pending"
+    elif task_counts["done"] > 0:
+        lane_status = "done"
+    else:
+        lane_status = "idle"
+
+    return {
+        "lane_id": lane_id,
+        "owner": owner,
+        "status": lane_status,
+        "task_counts": task_counts,
+        "tasks": tasks,
+        "heartbeat": {
+            "cycle": _safe_int(heartbeat.get("cycle", 0)),
+            "phase": str(heartbeat.get("phase", "")),
+            "pid": _safe_int(heartbeat.get("pid", 0)),
+            "timestamp": str(heartbeat.get("timestamp", "")),
+            "message": str(heartbeat.get("message", ""))[:200],
+        },
+        "metrics": {
+            "responses_total": _safe_int(metrics_summary.get("responses_total", 0)),
+            "cost_usd_total": _safe_float(metrics_summary.get("cost_usd_total", 0)),
+            "tokens_total": _safe_int(metrics_summary.get("tokens_total", 0)),
+            "first_time_pass_rate": _safe_float(metrics_summary.get("first_time_pass_rate", 0)),
+            "acceptance_pass_rate": _safe_float(metrics_summary.get("acceptance_pass_rate", 0)),
+            "latency_sec_avg": _safe_float(
+                (metrics_summary.get("by_owner", {}) or {}).get(owner, {}).get("latency_sec_avg", 0)
+            ),
+        },
+        "config": {
+            "execution_profile": str(config.get("execution_profile", "")),
+            "continuous": bool(config.get("continuous", False)),
+            "max_cycles": _safe_int(config.get("max_cycles", 0)),
+            "max_attempts": _safe_int(config.get("max_attempts", 0)),
+            "started_at": str(config.get("started_at", "")),
+        },
+    }
+
+
+# ── Event Collection ─────────────────────────────────────────────────────────
+
+def collect_events(artifacts_dir: Path, *, tail: int = 100) -> list[dict[str, Any]]:
+    """Collect recent conversation events across all lanes."""
+    lanes_dir = artifacts_dir / "autonomy" / "lanes"
+    if not lanes_dir.is_dir():
+        return []
+
+    all_events: list[dict[str, Any]] = []
+    for lane_dir in lanes_dir.iterdir():
+        if not lane_dir.is_dir():
+            continue
+        conv_file = lane_dir / "conversations.ndjson"
+        if not conv_file.exists():
+            continue
+        events = _read_ndjson(conv_file, tail=50)
+        for evt in events:
+            evt["lane_id"] = lane_dir.name
+        all_events.extend(events)
+
+    # Sort by timestamp descending
+    all_events.sort(key=lambda e: str(e.get("timestamp", "")), reverse=True)
+    return all_events[:tail]
+
+
+# ── Health Snapshot ──────────────────────────────────────────────────────────
+
+def collect_health(artifacts_dir: Path) -> dict[str, Any]:
+    """Read the current health snapshot from artifacts."""
+    health = _read_json_dict(artifacts_dir / "autonomy" / "health.json")
+    dashboard_health = _read_json_dict(artifacts_dir / "autonomy" / "dashboard_health.json")
+    return {
+        "health": health,
+        "collaboration": dashboard_health,
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Metrics Aggregation ─────────────────────────────────────────────────────
+
+def collect_metrics(artifacts_dir: Path) -> dict[str, Any]:
+    """Collect aggregated response metrics from all lanes."""
+    metrics_file = artifacts_dir / "autonomy" / "response_metrics_summary.json"
+    global_metrics = _read_json_dict(metrics_file)
+
+    # Also aggregate per-lane
+    lanes_dir = artifacts_dir / "autonomy" / "lanes"
+    per_lane: dict[str, Any] = {}
+    if lanes_dir.is_dir():
+        for lane_dir in lanes_dir.iterdir():
+            if not lane_dir.is_dir():
+                continue
+            lane_metrics = _read_json_dict(lane_dir / "response_metrics_summary.json")
+            if lane_metrics:
+                per_lane[lane_dir.name] = {
+                    "responses_total": _safe_int(lane_metrics.get("responses_total", 0)),
+                    "cost_usd_total": _safe_float(lane_metrics.get("cost_usd_total", 0)),
+                    "tokens_total": _safe_int(lane_metrics.get("tokens_total", 0)),
+                    "first_time_pass_rate": _safe_float(lane_metrics.get("first_time_pass_rate", 0)),
+                    "acceptance_pass_rate": _safe_float(lane_metrics.get("acceptance_pass_rate", 0)),
+                }
+
+    return {
+        "global": global_metrics,
+        "per_lane": per_lane,
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Git State ────────────────────────────────────────────────────────────────
+
+def collect_git_state(repo_dir: Path) -> dict[str, Any]:
+    """Collect git repository state (branches, recent commits)."""
+    result: dict[str, Any] = {"branches": [], "recent_commits": [], "branch_count": 0}
+
+    try:
+        branch_out = subprocess.run(
+            ["git", "-C", str(repo_dir), "branch", "-a", "--format=%(refname:short)"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+        if branch_out.returncode == 0:
+            branches = [b.strip() for b in branch_out.stdout.strip().splitlines() if b.strip()]
+            result["branch_count"] = len(branches)
+            result["branches"] = branches[:50]  # cap at 50
+    except Exception:
+        pass
+
+    try:
+        log_out = subprocess.run(
+            ["git", "-C", str(repo_dir), "log", "--oneline", "--all", "-20",
+             "--format=%H|%h|%s|%an|%ar|%aI"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+        if log_out.returncode == 0:
+            for line in log_out.stdout.strip().splitlines():
+                parts = line.split("|", 5)
+                if len(parts) >= 6:
+                    result["recent_commits"].append({
+                        "hash": parts[0], "short_hash": parts[1],
+                        "message": parts[2], "author": parts[3],
+                        "relative_time": parts[4], "timestamp": parts[5],
+                    })
+    except Exception:
+        pass
+
+    try:
+        current_branch = subprocess.run(
+            ["git", "-C", str(repo_dir), "branch", "--show-current"],
+            capture_output=True, text=True, check=False, timeout=5,
+        )
+        if current_branch.returncode == 0:
+            result["current_branch"] = current_branch.stdout.strip()
+    except Exception:
+        pass
+
+    return result
+
+
+# ── Connectivity ─────────────────────────────────────────────────────────────
+
+def collect_connectivity(artifacts_dir: Path) -> dict[str, Any]:
+    """Read model connectivity status."""
+    conn = _read_json_dict(artifacts_dir / "model_connectivity.json")
+    if not conn:
+        conn = _read_json_dict(artifacts_dir.parent / "artifacts" / "model_connectivity.json")
+    return conn
+
+
+# ── Checkpoints ──────────────────────────────────────────────────────────────
+
+def collect_checkpoints(artifacts_dir: Path) -> list[dict[str, Any]]:
+    """Read recent checkpoint files."""
+    cp_dir = artifacts_dir / "checkpoints"
+    if not cp_dir.is_dir():
+        return []
+    files = sorted(cp_dir.glob("*.json"), key=lambda p: p.name, reverse=True)[:5]
+    result: list[dict[str, Any]] = []
+    for f in files:
+        data = _read_json_dict(f)
+        if data:
+            result.append({"filename": f.name, "run_id": data.get("run_id", ""), "cycle": data.get("cycle", 0)})
+    return result
+
+
+# ── Swarm Cycle Report (19 health criteria) ─────────────────────────────────
+
+def collect_report(artifacts_dir: Path) -> dict[str, Any]:
+    """Read the comprehensive swarm cycle report with health criteria."""
+    report = _read_json_dict(artifacts_dir / "autonomy" / "swarm_cycle_report.json")
+    full_report = _read_json_dict(artifacts_dir / "autonomy" / "full_autonomy_report.json")
+    return {
+        "cycle_report": report,
+        "full_report": full_report,
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Cost Series ─────────────────────────────────────────────────────────────
+
+def collect_cost_series(artifacts_dir: Path) -> dict[str, Any]:
+    """Read cost time-series data for trend analysis."""
+    summary = _read_json_dict(artifacts_dir / "autonomy" / "provider_costs" / "summary.json")
+    return {
+        "hourly_series": summary.get("cost_series_hourly_24h", []),
+        "windows": summary.get("cost_windows_usd", {}),
+        "by_provider": summary.get("provider_cost_30d", {}),
+        "by_model": summary.get("model_cost_30d", {}),
+        "data_freshness": summary.get("data_freshness", {}),
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Privilege & Security ────────────────────────────────────────────────────
+
+def collect_privileges(artifacts_dir: Path) -> dict[str, Any]:
+    """Read current privilege state and breakglass events."""
+    priv = _read_json_dict(artifacts_dir / "autonomy" / "session_autonomy_privileges.json")
+    escalations = _read_ndjson(
+        artifacts_dir / "autonomy" / "privilege_escalations.ndjson", tail=20)
+    return {
+        "current": priv,
+        "recent_escalations": escalations,
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Policy Compliance ───────────────────────────────────────────────────────
+
+def collect_policies(artifacts_dir: Path) -> dict[str, Any]:
+    """Read all policy compliance health files."""
+    auto_dir = artifacts_dir / "autonomy"
+    policies: dict[str, Any] = {}
+    policy_files = [
+        ("git_delivery", "git_delivery_policy_health.json"),
+        ("git_hygiene", "git_hygiene_remediation.json"),
+        ("api_interop", "api_interop_policy_health.json"),
+        ("backend_upgrade", "backend_upgrade_policy_health.json"),
+        ("pr_tier", "pr_tier_policy_health.json"),
+        ("privilege", "privilege_policy_health.json"),
+    ]
+    for key, filename in policy_files:
+        data = _read_json_dict(auto_dir / filename)
+        if data:
+            policies[key] = data
+    return {
+        "policies": policies,
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Task Backlog ────────────────────────────────────────────────────────────
+
+def collect_task_backlog(artifacts_dir: Path) -> dict[str, Any]:
+    """Read the task backlog from config."""
+    # Try config/tasks.json relative to artifacts' parent (repo root)
+    repo_root = artifacts_dir.parent
+    tasks_data = _read_json(repo_root / "config" / "tasks.json")
+    tasks = tasks_data if isinstance(tasks_data, list) else []
+    # Summarize
+    by_owner: dict[str, int] = {}
+    by_priority: dict[str, int] = {}
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        owner = str(t.get("owner", "unknown"))
+        by_owner[owner] = by_owner.get(owner, 0) + 1
+        prio = str(t.get("priority", "?"))
+        by_priority[prio] = by_priority.get(prio, 0) + 1
+    return {
+        "tasks": tasks[:100],
+        "total": len(tasks),
+        "by_owner": by_owner,
+        "by_priority": by_priority,
+        "timestamp": _utc_now_iso(),
+    }
+
+
+# ── Response Metrics Stream ─────────────────────────────────────────────────
+
+def collect_response_stream(artifacts_dir: Path, *, tail: int = 50) -> list[dict[str, Any]]:
+    """Collect recent per-response metrics across all lanes for trend analysis."""
+    lanes_dir = artifacts_dir / "autonomy" / "lanes"
+    if not lanes_dir.is_dir():
+        return []
+    all_responses: list[dict[str, Any]] = []
+    for lane_dir in lanes_dir.iterdir():
+        if not lane_dir.is_dir():
+            continue
+        metrics_file = lane_dir / "response_metrics.ndjson"
+        if not metrics_file.exists():
+            continue
+        entries = _read_ndjson(metrics_file, tail=30)
+        for entry in entries:
+            entry["lane_id"] = lane_dir.name
+        all_responses.extend(entries)
+    all_responses.sort(key=lambda e: str(e.get("timestamp", "")), reverse=True)
+    return all_responses[:tail]
+
+
+# ── Full Snapshot ────────────────────────────────────────────────────────────
+
+def full_snapshot(artifacts_dir: Path, *, repo_dir: Path | None = None) -> dict[str, Any]:
+    """Build the complete swarm state snapshot for the dashboard."""
+    lanes = discover_lanes(artifacts_dir)
+    health = collect_health(artifacts_dir)
+    metrics = collect_metrics(artifacts_dir)
+    events = collect_events(artifacts_dir, tail=80)
+    checkpoints = collect_checkpoints(artifacts_dir)
+    connectivity = collect_connectivity(artifacts_dir)
+
+    git = collect_git_state(repo_dir) if repo_dir else {}
+
+    # Derive summary counts
+    owner_counts: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
+    total_cost = 0.0
+    total_tokens = 0
+    total_responses = 0
+    for lane in lanes:
+        owner = lane.get("owner", "unknown")
+        owner_counts[owner] = owner_counts.get(owner, 0) + 1
+        status = lane.get("status", "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        total_cost += _safe_float(lane.get("metrics", {}).get("cost_usd_total", 0))
+        total_tokens += _safe_int(lane.get("metrics", {}).get("tokens_total", 0))
+        total_responses += _safe_int(lane.get("metrics", {}).get("responses_total", 0))
+
+    # Alerts from health data
+    alerts: list[dict[str, Any]] = []
+    blocked_lanes = [l for l in lanes if l.get("status") == "blocked"]
+    for bl in blocked_lanes:
+        alerts.append({
+            "severity": "high",
+            "type": "blocked_lane",
+            "message": f"Lane {bl['lane_id']} is blocked",
+            "lane_id": bl["lane_id"],
+        })
+
+    # Stale heartbeats
+    for lane in lanes:
+        hb_ts = lane.get("heartbeat", {}).get("timestamp", "")
+        if hb_ts:
+            try:
+                parsed = datetime.fromisoformat(hb_ts)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                age = (datetime.now(timezone.utc) - parsed).total_seconds()
+                lane["heartbeat"]["age_sec"] = int(age)
+                if age > 300 and lane.get("status") != "done":
+                    alerts.append({
+                        "severity": "medium",
+                        "type": "stale_heartbeat",
+                        "message": f"Lane {lane['lane_id']} heartbeat stale ({int(age)}s)",
+                        "lane_id": lane["lane_id"],
+                    })
+            except Exception:
+                lane["heartbeat"]["age_sec"] = -1
+        else:
+            lane["heartbeat"]["age_sec"] = -1
+
+    # High retry/deadlock lanes
+    for lane in lanes:
+        for task in lane.get("tasks", []):
+            if _safe_int(task.get("deadlock_recoveries", 0)) >= 5:
+                alerts.append({
+                    "severity": "medium",
+                    "type": "deadlock_storm",
+                    "message": f"Task {task['task_id']}: {task['deadlock_recoveries']} deadlock recoveries",
+                    "lane_id": lane["lane_id"],
+                })
+
+    return {
+        "timestamp": _utc_now_iso(),
+        "summary": {
+            "lanes_total": len(lanes),
+            "owner_counts": owner_counts,
+            "status_counts": status_counts,
+            "total_cost_usd": round(total_cost, 4),
+            "total_tokens": total_tokens,
+            "total_responses": total_responses,
+            "alerts_count": len(alerts),
+        },
+        "lanes": lanes,
+        "health": health,
+        "metrics": metrics,
+        "events": events,
+        "alerts": alerts,
+        "git": git,
+        "connectivity": connectivity,
+        "checkpoints": checkpoints,
+    }
+
+
+# ── HTTP Handler ─────────────────────────────────────────────────────────────
+
+_FRONTEND_MAP = {
+    "nexus": "dashboard_v2_frontend.html",
+    "meridian": "dashboard_v2_meridian.html",
+    "prism": "dashboard_v2_prism.html",
+    "signal": "dashboard_v2_signal.html",
+}
+
+
+def _html_path(variant: str = "nexus") -> Path:
+    """Path to a dashboard HTML file (co-located with this module)."""
+    filename = _FRONTEND_MAP.get(variant, _FRONTEND_MAP["nexus"])
+    return Path(__file__).parent / filename
+
+
+def make_v2_handler(
+    artifacts_dir: Path,
+    *,
+    repo_dir: Path | None = None,
+) -> type[BaseHTTPRequestHandler]:
+    """Create an HTTP handler that serves the v2 dashboard."""
+    resolved_artifacts = artifacts_dir.resolve()
+    resolved_repo = repo_dir.resolve() if repo_dir else None
+
+    class V2Handler(BaseHTTPRequestHandler):
+        _artifacts = resolved_artifacts
+        _repo = resolved_repo
+
+        def log_message(self, fmt: str, *args: Any) -> None:
+            return
+
+        def _send_json(self, data: Any, status: int = 200) -> None:
+            body = json.dumps(data, indent=2, default=str).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_html(self, text: str, status: int = 200) -> None:
+            body = text.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_text(self, text: str, status: int = 200) -> None:
+            body = text.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _serve_frontend(self, variant: str) -> None:
+            html_file = _html_path(variant)
+            if html_file.exists():
+                self._send_html(html_file.read_text(encoding="utf-8"))
+            else:
+                self._send_html(
+                    "<html><body><h1>Dashboard frontend not found</h1>"
+                    f"<p>Expected at: {html_file}</p></body></html>",
+                    status=500,
+                )
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urllib_parse.urlparse(self.path)
+            path = parsed.path
+            qs = urllib_parse.parse_qs(parsed.query)
+
+            # ── Frontend routes ──
+            if path in ("/", "/v2", "/nexus"):
+                self._serve_frontend("nexus")
+                return
+            if path == "/meridian":
+                self._serve_frontend("meridian")
+                return
+            if path == "/prism":
+                self._serve_frontend("prism")
+                return
+            if path == "/signal":
+                self._serve_frontend("signal")
+                return
+
+            # ── Original API routes ──
+            if path == "/api/v2/snapshot":
+                data = full_snapshot(self._artifacts, repo_dir=self._repo)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/lanes":
+                data = discover_lanes(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path.startswith("/api/v2/lanes/"):
+                lane_id = path[len("/api/v2/lanes/"):]
+                lanes = discover_lanes(self._artifacts)
+                match = next((l for l in lanes if l["lane_id"] == lane_id), None)
+                if match:
+                    self._send_json(match)
+                else:
+                    self._send_json({"error": "lane not found"}, status=404)
+                return
+
+            if path == "/api/v2/events":
+                tail = _safe_int(qs.get("tail", [80])[0], 80)
+                data = collect_events(self._artifacts, tail=min(tail, 500))
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/health":
+                data = collect_health(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/metrics":
+                data = collect_metrics(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/git":
+                if self._repo:
+                    data = collect_git_state(self._repo)
+                    self._send_json(data)
+                else:
+                    self._send_json({"error": "repo_dir not configured"}, status=400)
+                return
+
+            # ── New enriched API routes ──
+            if path == "/api/v2/report":
+                data = collect_report(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/cost-series":
+                data = collect_cost_series(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/privileges":
+                data = collect_privileges(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/policies":
+                data = collect_policies(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/task-backlog":
+                data = collect_task_backlog(self._artifacts)
+                self._send_json(data)
+                return
+
+            if path == "/api/v2/response-stream":
+                tail = _safe_int(qs.get("tail", [50])[0], 50)
+                data = collect_response_stream(self._artifacts, tail=min(tail, 200))
+                self._send_json(data)
+                return
+
+            # ── Action API (GET) ──
+            if path == "/api/v2/actions":
+                self._send_json(dashboard_actions.get_action_catalog())
+                return
+
+            if path == "/api/v2/actions/audit":
+                audit_path = self._artifacts / "autonomy" / "dashboard_actions_audit.ndjson"
+                entries = _read_ndjson(audit_path, tail=100)
+                self._send_json(entries)
+                return
+
+            self._send_text("Not found\n", status=404)
+
+        def do_OPTIONS(self) -> None:  # noqa: N802
+            self.send_response(204)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urllib_parse.urlparse(self.path)
+            path = parsed.path
+
+            if not path.startswith("/api/v2/actions/"):
+                self._send_json({"error": "not found"}, status=404)
+                return
+
+            action_id = path[len("/api/v2/actions/"):]
+
+            # Parse request body
+            try:
+                content_length = int(self.headers.get("Content-Length", 0))
+                if content_length > 65536:
+                    self._send_json({"error": "request body too large"}, status=400)
+                    return
+                raw = self.rfile.read(content_length) if content_length > 0 else b""
+                body = json.loads(raw.decode("utf-8")) if raw else {}
+                if not isinstance(body, dict):
+                    self._send_json({"error": "request body must be a JSON object"}, status=400)
+                    return
+            except (ValueError, json.JSONDecodeError) as exc:
+                self._send_json({"error": f"invalid request body: {exc}"}, status=400)
+                return
+
+            result = dashboard_actions.dispatch_action(
+                action_id=action_id,
+                params=body.get("params", {}),
+                confirm_token=body.get("confirm_token", ""),
+                dry_run=body.get("dry_run", False),
+                artifacts_dir=self._artifacts,
+                repo_dir=self._repo,
+            )
+
+            if not result.ok and "confirmation" in result.message.lower():
+                status = 409
+            elif not result.ok and "Unknown action" in result.message:
+                status = 404
+            elif not result.ok and "Rate limit" in result.message:
+                status = 429
+            elif not result.ok:
+                status = 400
+            else:
+                status = 200
+            self._send_json(result.to_dict(), status=status)
+
+    return V2Handler
+
+
+def run_v2_server(
+    *,
+    artifacts_dir: Path,
+    repo_dir: Path | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8788,
+) -> None:
+    """Start the v2 dashboard HTTP server."""
+    handler = make_v2_handler(artifacts_dir, repo_dir=repo_dir)
+    server = ThreadingHTTPServer((host, int(port)), handler)
+    url = f"http://{host}:{server.server_port}/"
+    print(f"NEXUS dashboard serving at {url}")
+    print(f"  artifacts: {artifacts_dir.resolve()}")
+    if repo_dir:
+        print(f"  repo: {repo_dir.resolve()}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/src/orxaq_autonomy/dashboard_v2_frontend.html
+++ b/src/orxaq_autonomy/dashboard_v2_frontend.html
@@ -1,0 +1,752 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NEXUS — Swarm Command</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%;overflow:hidden;background:#000;font-family:'SF Mono','Fira Code','Cascadia Code',monospace;color:#c0d8e8}
+
+/* ── Canvas ambient layer ── */
+canvas#bg{position:fixed;top:0;left:0;width:100%;height:100%;z-index:0}
+
+/* ── HUD chrome ── */
+.hud{position:fixed;z-index:10;pointer-events:none}
+.hud *{pointer-events:auto}
+
+/* Top bar */
+.hud-top{top:0;left:0;right:0;display:flex;justify-content:space-between;align-items:center;padding:8px 16px;background:linear-gradient(180deg,rgba(0,16,32,0.92) 0%,transparent 100%)}
+.logo{font-size:11px;font-weight:700;letter-spacing:0.16em;text-transform:uppercase;color:#4dd8e8;display:flex;align-items:center;gap:10px}
+.health-orb{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:700;transition:all 0.6s}
+.health-orb.ok{background:rgba(0,232,123,0.1);border:2px solid rgba(0,232,123,0.4);color:#00e87b;box-shadow:0 0 10px rgba(0,232,123,0.08)}
+.health-orb.warn{background:rgba(232,168,0,0.1);border:2px solid rgba(232,168,0,0.4);color:#e8a800;box-shadow:0 0 10px rgba(232,168,0,0.08)}
+.health-orb.crit{background:rgba(232,48,48,0.1);border:2px solid rgba(232,48,48,0.4);color:#e83030;box-shadow:0 0 10px rgba(232,48,48,0.08)}
+.top-stats{display:flex;gap:16px;font-size:10px;align-items:center}
+.stat{display:flex;flex-direction:column;align-items:center;gap:1px}
+.stat-label{font-size:7px;color:#3a6878;text-transform:uppercase;letter-spacing:0.12em}
+.stat-val{font-size:13px;font-weight:700;color:#4dd8e8;font-variant-numeric:tabular-nums}
+.stat-val.warn{color:#e8a800}.stat-val.crit{color:#e83030}.stat-val.ok{color:#00e87b}
+.clock{font-size:10px;color:#3a6878;font-variant-numeric:tabular-nums}
+
+/* Bottom bar */
+.hud-bottom{bottom:0;left:0;right:0;display:flex;justify-content:space-between;align-items:center;padding:6px 16px;background:linear-gradient(0deg,rgba(0,16,32,0.92) 0%,transparent 100%);font-size:9px}
+.git-strip{display:flex;gap:12px;align-items:center}
+.git-commit{display:flex;align-items:center;gap:4px;opacity:0.7;transition:opacity 0.2s}
+.git-commit:hover{opacity:1}
+.git-hash{color:#4dd8e8;font-size:8px}.git-msg{color:#6a9aaa;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.git-author{font-size:7px;padding:1px 4px;border-radius:2px;font-weight:600;text-transform:uppercase}
+.conn-strip{display:flex;gap:10px}
+.conn{display:flex;align-items:center;gap:4px;font-size:8px}
+.conn-dot{width:5px;height:5px;border-radius:50%}
+
+/* Left panel: Lanes */
+.hud-left{top:44px;left:0;bottom:32px;width:220px;padding:10px;display:flex;flex-direction:column;overflow-y:auto;background:linear-gradient(90deg,rgba(0,12,24,0.6) 0%,transparent 100%)}
+.hud-left::-webkit-scrollbar{width:2px}.hud-left::-webkit-scrollbar-thumb{background:#0a2a3a}
+.owner-group{margin-bottom:8px}
+.owner-title{font-size:7px;text-transform:uppercase;letter-spacing:0.16em;margin-bottom:4px;padding-bottom:3px;border-bottom:1px solid rgba(255,255,255,0.04)}
+.lane{display:flex;align-items:center;gap:6px;padding:5px 6px;border-radius:3px;font-size:9px;cursor:pointer;transition:all 0.15s;border-left:2px solid transparent;position:relative}
+.lane:hover{background:rgba(77,216,232,0.06)}
+.lane.selected{border-left-color:#4dd8e8;background:rgba(77,216,232,0.04)}
+.lane .l-dot{width:5px;height:5px;border-radius:50%;flex-shrink:0}
+.lane .l-name{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#7ab0c0;font-size:8px}
+.lane .l-stat{font-size:7px;color:#3a6878;font-variant-numeric:tabular-nums}
+.lane .l-hb{position:absolute;right:4px;top:2px;font-size:6px;color:#3a5868}
+.progress-micro{height:2px;background:rgba(255,255,255,0.03);border-radius:1px;margin-top:2px;overflow:hidden}
+.progress-micro-fill{height:100%;border-radius:1px;transition:width 0.4s}
+
+/* Right panel: Events + Alerts */
+.hud-right{top:44px;right:0;bottom:32px;width:280px;padding:10px;display:flex;flex-direction:column;background:linear-gradient(270deg,rgba(0,12,24,0.6) 0%,transparent 100%)}
+.panel-title{font-size:7px;color:#3a6878;text-transform:uppercase;letter-spacing:0.16em;margin-bottom:4px;padding-bottom:3px;border-bottom:1px solid rgba(255,255,255,0.04);display:flex;justify-content:space-between}
+.alert-zone{margin-bottom:8px}
+.alert{padding:5px 8px;margin-bottom:2px;border-radius:3px;font-size:9px;border-left:2px solid;animation:alertIn 0.3s ease-out}
+.alert.high{border-color:#e83030;background:rgba(232,48,48,0.06);color:#d04040}
+.alert.medium{border-color:#e8a800;background:rgba(232,168,0,0.04);color:#c09030}
+.alert .alert-type{font-size:7px;text-transform:uppercase;letter-spacing:0.06em;font-weight:700;opacity:0.7}
+@keyframes alertIn{from{opacity:0;transform:translateX(12px)}to{opacity:1;transform:translateX(0)}}
+.feed{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:1px}
+.feed::-webkit-scrollbar{width:2px}.feed::-webkit-scrollbar-thumb{background:#0a2a3a}
+.evt{padding:3px 6px;font-size:8px;border-left:2px solid #1a3040;animation:fadeSlide 0.25s ease-out}
+.evt .evt-time{font-size:6px;color:#2a5060}.evt .evt-body{margin-top:1px;color:#6a9aaa}
+.evt .evt-lane{font-size:6px;color:#3a6878}
+@keyframes fadeSlide{from{opacity:0;transform:translateX(10px)}to{opacity:1;transform:translateX(0)}}
+
+/* Center: detail overlay */
+#detail-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,8,16,0.75);z-index:100;display:none;align-items:center;justify-content:center;backdrop-filter:blur(6px)}
+#detail-overlay.open{display:flex}
+#detail-panel{background:rgba(0,18,32,0.97);border:1px solid #0a2a4a;border-radius:8px;padding:20px;max-width:520px;width:92%;max-height:82vh;overflow-y:auto;position:relative}
+#detail-panel .close-btn{position:absolute;top:8px;right:10px;background:none;border:none;color:#3a6878;font-size:16px;cursor:pointer}
+#detail-panel h3{font-size:11px;color:#4dd8e8;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:10px}
+.d-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-bottom:12px}
+.d-card{background:rgba(20,35,50,0.5);border-radius:4px;padding:8px;text-align:center}
+.d-card-label{font-size:7px;color:#3a6878;text-transform:uppercase;letter-spacing:0.1em}
+.d-card-val{font-size:14px;font-weight:700;margin-top:2px}
+.d-section{font-size:7px;color:#3a6878;text-transform:uppercase;letter-spacing:0.14em;margin:12px 0 6px;padding-top:8px;border-top:1px solid #0a1a2a}
+.d-task{padding:5px 8px;margin:2px 0;font-size:9px;border-left:2px solid #1a3040;background:rgba(10,20,30,0.4);border-radius:2px}
+.d-task-status{font-size:7px;text-transform:uppercase;font-weight:700;letter-spacing:0.06em}
+.d-task-summary{color:#6a9aaa;margin-top:1px}
+
+/* Loading state */
+.loading{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);z-index:200;color:#3a6878;font-size:11px;text-align:center}
+.loading .spinner{width:24px;height:24px;border:2px solid #0a2a3a;border-top-color:#4dd8e8;border-radius:50%;animation:spin 0.8s linear infinite;margin:0 auto 8px}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* Refresh indicator */
+.refresh-dot{width:4px;height:4px;border-radius:50%;background:#4dd8e8;opacity:0;transition:opacity 0.3s;margin-left:6px}
+.refresh-dot.active{opacity:1;animation:pulse 0.5s ease-out}
+@keyframes pulse{0%{transform:scale(1)}50%{transform:scale(2)}100%{transform:scale(1)}}
+
+/* Responsive */
+@media(max-width:800px){
+  .hud-left{width:160px}.hud-right{width:200px}
+  .top-stats{gap:8px}.stat-val{font-size:11px}
+}
+@media(max-width:600px){
+  .hud-left,.hud-right{display:none}
+  .hud-top{padding:6px 10px}
+}
+</style>
+</head>
+<body>
+
+<canvas id="bg"></canvas>
+
+<!-- Loading state -->
+<div class="loading" id="loading">
+  <div class="spinner"></div>
+  <div>Connecting to swarm...</div>
+</div>
+
+<!-- Top HUD -->
+<div class="hud hud-top" id="top-bar" style="display:none">
+  <div class="logo">
+    <div class="health-orb ok" id="health-orb">0</div>
+    <span>NEXUS — Swarm Command</span>
+    <div class="refresh-dot" id="refresh-dot"></div>
+  </div>
+  <div class="top-stats" id="top-stats"></div>
+  <div class="clock" id="clock"></div>
+</div>
+
+<!-- Left: Lanes -->
+<div class="hud hud-left" id="lane-panel" style="display:none">
+  <div class="panel-title"><span>Lanes</span><span id="lane-count"></span></div>
+  <div id="lane-list"></div>
+</div>
+
+<!-- Right: Events + Alerts -->
+<div class="hud hud-right" id="event-panel" style="display:none">
+  <div class="alert-zone" id="alert-zone"></div>
+  <div class="panel-title"><span>Event Stream</span><span id="evt-count"></span></div>
+  <div class="feed" id="event-feed"></div>
+</div>
+
+<!-- Bottom: Git + Connectivity -->
+<div class="hud hud-bottom" id="bottom-bar" style="display:none">
+  <div class="git-strip" id="git-strip"></div>
+  <div class="conn-strip" id="conn-strip"></div>
+</div>
+
+<!-- Detail Overlay -->
+<div id="detail-overlay" onclick="if(event.target===this)closeDetail()">
+  <div id="detail-panel">
+    <button class="close-btn" onclick="closeDetail()">&times;</button>
+    <div id="detail-body"></div>
+  </div>
+</div>
+
+<script>
+// ═══════════════════════════════════════════════════════════════════
+// STATE
+// ═══════════════════════════════════════════════════════════════════
+let DATA = null;
+let selectedLaneId = null;
+let pollTimer = null;
+const POLL_INTERVAL = 5000;
+const OWNER_COLORS = {codex:'#00c8ff',gemini:'#ff8800',claude:'#a855f7',unknown:'#5a7a8a'};
+const STATUS_COLORS = {done:'#00e87b',in_progress:'#4dd8e8',blocked:'#e83030',pending:'#e8a800',idle:'#3a5868'};
+const EVT_BORDER = {
+  task_selected:'#4dd8e8',task_done:'#00e87b',task_blocked:'#e83030',
+  routing_decision:'#8a60d8',agent_error:'#e8a800',prompt:'#2a5a7a',
+  conversation_start:'#4dd8e8',conversation_end:'#00e87b',
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// CANVAS — Ambient awareness layer
+// ═══════════════════════════════════════════════════════════════════
+const canvas = document.getElementById('bg');
+const ctx = canvas.getContext('2d');
+const dpr = window.devicePixelRatio || 1;
+let W, H, cx, cy;
+
+function resize() {
+  W = window.innerWidth; H = window.innerHeight;
+  canvas.width = W * dpr; canvas.height = H * dpr;
+  canvas.style.width = W + 'px'; canvas.style.height = H + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  cx = W / 2; cy = H / 2;
+}
+resize();
+window.addEventListener('resize', resize);
+
+// Particles
+class Particle {
+  constructor(type) {
+    const angle = Math.random() * Math.PI * 2;
+    const dist = 60 + Math.random() * Math.min(W, H) * 0.35;
+    this.x = cx + Math.cos(angle) * dist;
+    this.y = cy + Math.sin(angle) * dist;
+    this.vx = (Math.random() - 0.5) * 0.25;
+    this.vy = (Math.random() - 0.5) * 0.25;
+    this.life = 1;
+    this.decay = 0.001 + Math.random() * 0.004;
+    this.type = type;
+    this.size = type === 'error' ? 2.5 : type === 'event' ? 1.8 : 1.2;
+    this.color = type === 'error' ? [232,48,48] : type === 'event' ? [77,216,232] : [0,232,123];
+  }
+  update() {
+    this.x += this.vx; this.y += this.vy; this.life -= this.decay;
+    this.vx += (cx - this.x) * 0.00002;
+    this.vy += (cy - this.y) * 0.00002;
+  }
+  draw(c) {
+    if (this.life <= 0) return;
+    const [r,g,b] = this.color;
+    c.beginPath();
+    c.arc(this.x, this.y, this.size * this.life, 0, Math.PI * 2);
+    c.fillStyle = `rgba(${r},${g},${b},${this.life * 0.5})`;
+    c.fill();
+    c.beginPath();
+    c.arc(this.x, this.y, this.size * 2.5 * this.life, 0, Math.PI * 2);
+    c.fillStyle = `rgba(${r},${g},${b},${this.life * 0.06})`;
+    c.fill();
+  }
+}
+
+let particles = [];
+let commitPulses = [];
+let radarAngle = 0;
+let frame = 0;
+let ambientHue = [0, 30, 60]; // RGB tint for ambient health
+
+function spawnParticle() {
+  if (!DATA) return;
+  const alerts = DATA.alerts || [];
+  const hasErrors = alerts.some(a => a.severity === 'high');
+  const types = hasErrors
+    ? ['task','event','error','error','event']
+    : ['task','task','task','event','event'];
+  particles.push(new Particle(types[Math.floor(Math.random() * types.length)]));
+}
+
+function triggerCommitPulse() {
+  commitPulses.push({ r: 0, alpha: 0.25 });
+}
+
+function drawGrid() {
+  ctx.strokeStyle = 'rgba(77,216,232,0.012)';
+  ctx.lineWidth = 1;
+  const step = 50;
+  for (let x = 0; x < W; x += step) {
+    ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
+  }
+  for (let y = 0; y < H; y += step) {
+    ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+  }
+  // Scanlines
+  ctx.fillStyle = 'rgba(0,0,0,0.025)';
+  for (let y = 0; y < H; y += 3) ctx.fillRect(0, y, W, 1);
+}
+
+function drawRadar() {
+  const r = Math.min(W, H) * 0.22;
+  // Rings
+  for (const rf of [1, 0.65, 0.35]) {
+    ctx.beginPath();
+    ctx.arc(cx, cy, r * rf, 0, Math.PI * 2);
+    ctx.strokeStyle = 'rgba(77,216,232,0.04)';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  }
+  // Cross
+  ctx.strokeStyle = 'rgba(77,216,232,0.025)';
+  ctx.beginPath();
+  ctx.moveTo(cx - r, cy); ctx.lineTo(cx + r, cy);
+  ctx.moveTo(cx, cy - r); ctx.lineTo(cx, cy + r);
+  ctx.stroke();
+
+  // Sweep
+  radarAngle += 0.006;
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.arc(cx, cy, r, radarAngle - 0.4, radarAngle);
+  ctx.closePath();
+  const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+  g.addColorStop(0, 'rgba(77,216,232,0.0)');
+  g.addColorStop(0.5, 'rgba(77,216,232,0.03)');
+  g.addColorStop(1, 'rgba(77,216,232,0.08)');
+  ctx.fillStyle = g;
+  ctx.fill();
+
+  // Sweep line
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.lineTo(cx + Math.cos(radarAngle) * r, cy + Math.sin(radarAngle) * r);
+  ctx.strokeStyle = 'rgba(77,216,232,0.18)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  // Lane blips
+  if (DATA && DATA.lanes) {
+    const lanes = DATA.lanes;
+    lanes.forEach((lane, i) => {
+      const a = (i / Math.max(lanes.length, 1)) * Math.PI * 2 - Math.PI / 2;
+      const taskPct = lane.task_counts ?
+        ((lane.task_counts.done || 0) / Math.max(Object.values(lane.task_counts).reduce((s,v)=>s+v,0), 1)) : 0.5;
+      const d = r * 0.3 + taskPct * r * 0.5;
+      const bx = cx + Math.cos(a) * Math.min(d, r * 0.88);
+      const by = cy + Math.sin(a) * Math.min(d, r * 0.88);
+      const c = STATUS_COLORS[lane.status] || '#3a5868';
+
+      // Proximity glow from sweep
+      const angleDiff = Math.abs(((radarAngle % (Math.PI*2)) + Math.PI*2) % (Math.PI*2) - ((a % (Math.PI*2)) + Math.PI*2) % (Math.PI*2));
+      const intensity = angleDiff < 0.5 ? (0.5 - angleDiff) / 0.5 : 0;
+      const alpha = 0.25 + intensity * 0.75;
+
+      ctx.beginPath();
+      ctx.arc(bx, by, 2.5 + intensity * 3, 0, Math.PI * 2);
+      ctx.fillStyle = c.replace(')', `,${alpha})`).replace('rgb', 'rgba').replace('#', '');
+      // Convert hex to rgba
+      const hr = parseInt(c.slice(1,3),16), hg = parseInt(c.slice(3,5),16), hb = parseInt(c.slice(5,7),16);
+      ctx.fillStyle = `rgba(${hr},${hg},${hb},${alpha.toFixed(2)})`;
+      ctx.fill();
+
+      if (lane.status === 'in_progress') {
+        ctx.beginPath();
+        ctx.arc(bx, by, 7 + Math.sin(Date.now()/600) * 2, 0, Math.PI * 2);
+        ctx.strokeStyle = `rgba(${hr},${hg},${hb},0.15)`;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+    });
+  }
+}
+
+function drawBudgetArc() {
+  if (!DATA || !DATA.summary) return;
+  const r = Math.min(W, H) * 0.22 + 16;
+  const startA = -Math.PI * 0.75;
+  const endA = -Math.PI * 0.25;
+  // Use health data budget if available
+  const health = DATA.health?.health || {};
+  const cap = health.budget_daily_cap || 100;
+  const spent = DATA.summary.total_cost_usd || 0;
+  const pct = Math.min(spent / cap, 1);
+  const spentAngle = startA + pct * (endA - startA);
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, startA, endA);
+  ctx.strokeStyle = 'rgba(77,216,232,0.04)';
+  ctx.lineWidth = 2.5;
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, startA, spentAngle);
+  ctx.strokeStyle = pct > 0.8 ? 'rgba(232,48,48,0.4)' : pct > 0.5 ? 'rgba(232,168,0,0.4)' : 'rgba(0,232,123,0.35)';
+  ctx.lineWidth = 2.5;
+  ctx.stroke();
+
+  ctx.font = '7px monospace';
+  ctx.fillStyle = 'rgba(77,216,232,0.25)';
+  ctx.textAlign = 'center';
+  ctx.fillText(`BUDGET $${spent.toFixed(2)} / $${cap}`, cx, cy - r - 6);
+}
+
+function drawCommitPulses() {
+  commitPulses = commitPulses.filter(p => p.alpha > 0.005);
+  commitPulses.forEach(p => {
+    p.r += 1.2;
+    p.alpha *= 0.988;
+    ctx.beginPath();
+    ctx.arc(cx, cy, p.r, 0, Math.PI * 2);
+    ctx.strokeStyle = `rgba(0,232,123,${p.alpha})`;
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  });
+}
+
+function render() {
+  ctx.clearRect(0, 0, W, H);
+
+  // Ambient gradient (shifts with health)
+  const [ar, ag, ab] = ambientHue;
+  const bg = ctx.createRadialGradient(cx, cy, 0, cx, cy, Math.max(W, H) * 0.7);
+  bg.addColorStop(0, `rgb(${2+ar},${8+ag},${16+ab})`);
+  bg.addColorStop(1, '#000306');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
+
+  drawGrid();
+  drawRadar();
+  drawBudgetArc();
+  drawCommitPulses();
+
+  if (frame % 10 === 0) spawnParticle();
+  particles = particles.filter(p => p.life > 0);
+  particles.forEach(p => { p.update(); p.draw(ctx); });
+  if (frame % 400 === 0 && DATA) triggerCommitPulse();
+
+  frame++;
+  requestAnimationFrame(render);
+}
+render();
+
+// ═══════════════════════════════════════════════════════════════════
+// DATA FETCHING
+// ═══════════════════════════════════════════════════════════════════
+async function fetchSnapshot() {
+  try {
+    const resp = await fetch('/api/v2/snapshot');
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    DATA = await resp.json();
+    updateDOM();
+    updateAmbient();
+    return true;
+  } catch (e) {
+    console.warn('Fetch failed:', e);
+    return false;
+  }
+}
+
+function updateAmbient() {
+  if (!DATA) return;
+  const alerts = DATA.alerts || [];
+  const hasCrit = alerts.some(a => a.severity === 'high');
+  const hasWarn = alerts.length > 0;
+  if (hasCrit) {
+    ambientHue = [12, 2, 4]; // red tint
+  } else if (hasWarn) {
+    ambientHue = [8, 6, 0]; // amber tint
+  } else {
+    ambientHue = [0, 4, 10]; // blue/healthy tint
+  }
+}
+
+function startPolling() {
+  fetchSnapshot().then(ok => {
+    document.getElementById('loading').style.display = 'none';
+    ['top-bar','lane-panel','event-panel','bottom-bar'].forEach(id => {
+      document.getElementById(id).style.display = '';
+    });
+  });
+  pollTimer = setInterval(async () => {
+    const dot = document.getElementById('refresh-dot');
+    dot.classList.add('active');
+    await fetchSnapshot();
+    setTimeout(() => dot.classList.remove('active'), 400);
+  }, POLL_INTERVAL);
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// DOM UPDATES
+// ═══════════════════════════════════════════════════════════════════
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+function updateDOM() {
+  if (!DATA) return;
+  updateTopBar();
+  updateLanes();
+  updateEvents();
+  updateAlerts();
+  updateBottomBar();
+}
+
+function updateTopBar() {
+  const s = DATA.summary || {};
+  const alerts = DATA.alerts || [];
+  const hasCrit = alerts.some(a => a.severity === 'high');
+  const orb = document.getElementById('health-orb');
+  orb.textContent = alerts.length || '\u2713';
+  orb.className = 'health-orb ' + (hasCrit ? 'crit' : alerts.length > 0 ? 'warn' : 'ok');
+
+  const sc = s.status_counts || {};
+  const stats = [
+    { label: 'Lanes', val: s.lanes_total || 0, cls: '' },
+    { label: 'Done', val: sc.done || 0, cls: 'ok' },
+    { label: 'Active', val: sc.in_progress || 0, cls: '' },
+    { label: 'Blocked', val: sc.blocked || 0, cls: (sc.blocked || 0) > 0 ? 'crit' : '' },
+    { label: 'Cost', val: '$' + (s.total_cost_usd || 0).toFixed(2), cls: '' },
+    { label: 'Tokens', val: formatTokens(s.total_tokens || 0), cls: '' },
+    { label: 'Responses', val: s.total_responses || 0, cls: '' },
+    { label: 'Alerts', val: s.alerts_count || 0, cls: (s.alerts_count || 0) > 0 ? 'warn' : '' },
+  ];
+
+  const statsEl = document.getElementById('top-stats');
+  statsEl.innerHTML = stats.map(st =>
+    `<div class="stat"><span class="stat-label">${st.label}</span><span class="stat-val ${st.cls}">${st.val}</span></div>`
+  ).join('');
+}
+
+function formatTokens(n) {
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(0) + 'K';
+  return String(n);
+}
+
+function updateLanes() {
+  const lanes = DATA.lanes || [];
+  document.getElementById('lane-count').textContent = lanes.length;
+
+  // Group by owner
+  const grouped = {};
+  lanes.forEach(l => {
+    const o = l.owner || 'unknown';
+    if (!grouped[o]) grouped[o] = [];
+    grouped[o].push(l);
+  });
+
+  const list = document.getElementById('lane-list');
+  list.innerHTML = '';
+
+  Object.entries(grouped).sort().forEach(([owner, ownerLanes]) => {
+    const color = OWNER_COLORS[owner] || OWNER_COLORS.unknown;
+    const group = document.createElement('div');
+    group.className = 'owner-group';
+    group.innerHTML = `<div class="owner-title" style="color:${color}">${esc(owner.toUpperCase())} \u2014 ${ownerLanes.length}</div>`;
+
+    ownerLanes.forEach(lane => {
+      const tc = lane.task_counts || {};
+      const total = (tc.done||0) + (tc.in_progress||0) + (tc.pending||0) + (tc.blocked||0);
+      const done = tc.done || 0;
+      const pct = total > 0 ? (done / total * 100) : 0;
+      const sc = STATUS_COLORS[lane.status] || '#3a5868';
+      const hbAge = lane.heartbeat?.age_sec;
+      const hbStr = hbAge != null && hbAge >= 0 ? hbAge + 's' : '';
+
+      const div = document.createElement('div');
+      div.className = 'lane' + (selectedLaneId === lane.lane_id ? ' selected' : '');
+      div.innerHTML = `
+        <span class="l-dot" style="background:${sc};box-shadow:0 0 4px ${sc}"></span>
+        <span class="l-name">${esc(lane.lane_id)}</span>
+        <span class="l-stat">${done}/${total}</span>
+        ${hbStr ? `<span class="l-hb">${esc(hbStr)}</span>` : ''}
+        <div class="progress-micro" style="width:100%"><div class="progress-micro-fill" style="width:${pct}%;background:${sc}"></div></div>
+      `;
+      div.onclick = () => showLaneDetail(lane);
+      group.appendChild(div);
+    });
+
+    list.appendChild(group);
+  });
+}
+
+function updateAlerts() {
+  const alerts = DATA.alerts || [];
+  const zone = document.getElementById('alert-zone');
+  if (alerts.length === 0) {
+    zone.innerHTML = '';
+    return;
+  }
+  zone.innerHTML = `<div class="panel-title"><span>Alerts</span><span style="color:#e83030">${alerts.length}</span></div>` +
+    alerts.slice(0, 8).map(a =>
+      `<div class="alert ${esc(a.severity || 'medium')}" onclick="alertClick('${esc(a.lane_id || '')}')">
+        <div class="alert-type">${esc(a.type || '')}</div>
+        <div>${esc(a.message || '')}</div>
+      </div>`
+    ).join('');
+}
+
+function alertClick(laneId) {
+  if (!laneId || !DATA) return;
+  const lane = (DATA.lanes || []).find(l => l.lane_id === laneId);
+  if (lane) showLaneDetail(lane);
+}
+
+function updateEvents() {
+  const events = DATA.events || [];
+  document.getElementById('evt-count').textContent = events.length;
+
+  const feed = document.getElementById('event-feed');
+  feed.innerHTML = events.slice(0, 60).map(evt => {
+    const type = evt.type || evt.event_type || '';
+    const borderColor = EVT_BORDER[type] || '#1a3040';
+    const ts = evt.timestamp ? evt.timestamp.slice(11, 19) : '';
+    const laneId = evt.lane_id || '';
+    const body = evt.message || evt.summary || evt.body || type;
+    return `<div class="evt" style="border-left-color:${borderColor}">
+      <div class="evt-time">${esc(ts)} <span class="evt-lane">${esc(laneId)}</span></div>
+      <div class="evt-body">${esc(String(body).slice(0, 120))}</div>
+    </div>`;
+  }).join('');
+}
+
+function updateBottomBar() {
+  // Git
+  const git = DATA.git || {};
+  const commits = git.recent_commits || [];
+  const gitStrip = document.getElementById('git-strip');
+  const branch = git.current_branch || '';
+  gitStrip.innerHTML = `<span style="color:#3a6878;font-size:8px">GIT</span>` +
+    (branch ? `<span style="color:#4dd8e8;font-size:8px">${esc(branch)}</span>` : '') +
+    `<span style="color:#3a6878;font-size:7px">${git.branch_count || 0} branches</span>` +
+    commits.slice(0, 4).map(c => {
+      const authorColor = OWNER_COLORS[c.author] || '#5a7a8a';
+      return `<div class="git-commit">
+        <span class="git-hash">${esc((c.short_hash || c.hash || '').slice(0,7))}</span>
+        <span class="git-msg">${esc((c.message || '').slice(0,40))}</span>
+        <span class="git-author" style="background:${authorColor}20;color:${authorColor}">${esc(c.author || '')}</span>
+      </div>`;
+    }).join('');
+
+  // Connectivity
+  const conn = DATA.connectivity || {};
+  const connStrip = document.getElementById('conn-strip');
+  if (conn.endpoints && Array.isArray(conn.endpoints)) {
+    connStrip.innerHTML = conn.endpoints.slice(0, 5).map(ep => {
+      const ok = ep.ok || ep.status === 'ok';
+      return `<div class="conn">
+        <div class="conn-dot" style="background:${ok?'#00e87b':'#e83030'};box-shadow:0 0 3px ${ok?'#00e87b':'#e83030'}"></div>
+        <span style="color:${ok?'#5a8a9a':'#c06060'}">${esc(ep.id || ep.name || '')}</span>
+      </div>`;
+    }).join('');
+  } else {
+    connStrip.innerHTML = '<span style="color:#3a5868">No connectivity data</span>';
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// DETAIL PANEL
+// ═══════════════════════════════════════════════════════════════════
+function closeDetail() {
+  document.getElementById('detail-overlay').classList.remove('open');
+  selectedLaneId = null;
+  updateLanes();
+}
+
+function showLaneDetail(lane) {
+  selectedLaneId = lane.lane_id;
+  updateLanes();
+  const overlay = document.getElementById('detail-overlay');
+  const body = document.getElementById('detail-body');
+  const ownerColor = OWNER_COLORS[lane.owner] || OWNER_COLORS.unknown;
+  const statusColor = STATUS_COLORS[lane.status] || '#3a5868';
+
+  const tc = lane.task_counts || {};
+  const total = (tc.done||0) + (tc.in_progress||0) + (tc.pending||0) + (tc.blocked||0);
+  const hb = lane.heartbeat || {};
+  const metrics = lane.metrics || {};
+  const config = lane.config || {};
+
+  let h = `<h3 style="color:${ownerColor}">\u2B21 ${esc(lane.lane_id)}</h3>`;
+
+  // Summary cards
+  h += `<div class="d-grid">
+    <div class="d-card"><div class="d-card-label">Status</div><div class="d-card-val" style="color:${statusColor}">${esc((lane.status||'').toUpperCase().replace('_',' '))}</div></div>
+    <div class="d-card"><div class="d-card-label">Progress</div><div class="d-card-val" style="color:${ownerColor}">${tc.done||0} / ${total}</div></div>
+    <div class="d-card"><div class="d-card-label">Cost</div><div class="d-card-val">$${(metrics.cost_usd_total||0).toFixed(2)}</div></div>
+    <div class="d-card"><div class="d-card-label">Heartbeat</div><div class="d-card-val" style="color:${(hb.age_sec||0)>120?'#e8a800':'#c0d8e8'}">${hb.age_sec != null && hb.age_sec >= 0 ? hb.age_sec+'s' : 'N/A'}</div></div>
+    <div class="d-card"><div class="d-card-label">Owner</div><div class="d-card-val" style="color:${ownerColor}">${esc((lane.owner||'').toUpperCase())}</div></div>
+    <div class="d-card"><div class="d-card-label">Tokens</div><div class="d-card-val">${formatTokens(metrics.tokens_total||0)}</div></div>
+    <div class="d-card"><div class="d-card-label">Pass Rate</div><div class="d-card-val" style="color:${(metrics.first_time_pass_rate||0)<0.5?'#e8a800':'#00e87b'}">${((metrics.first_time_pass_rate||0)*100).toFixed(0)}%</div></div>
+    <div class="d-card"><div class="d-card-label">Responses</div><div class="d-card-val">${metrics.responses_total||0}</div></div>
+  </div>`;
+
+  // Heartbeat detail
+  if (hb.phase || hb.cycle) {
+    h += `<div class="d-section">Heartbeat</div>`;
+    h += `<div style="font-size:9px;color:#6a9aaa;padding:6px;background:rgba(10,20,30,0.4);border-radius:3px">`;
+    if (hb.phase) h += `Phase: <span style="color:#4dd8e8">${esc(hb.phase)}</span> &middot; `;
+    if (hb.cycle) h += `Cycle: <span style="color:#4dd8e8">${hb.cycle}</span> &middot; `;
+    if (hb.message) h += `${esc(hb.message)}`;
+    h += `</div>`;
+  }
+
+  // Tasks
+  const tasks = lane.tasks || [];
+  if (tasks.length > 0) {
+    h += `<div class="d-section">Tasks (${tasks.length})</div>`;
+    tasks.forEach(t => {
+      const tsc = STATUS_COLORS[t.status] || '#3a5868';
+      h += `<div class="d-task" style="border-left-color:${tsc}">
+        <div class="d-task-status" style="color:${tsc}">${esc((t.status||'').toUpperCase())} \u2014 ${esc(t.task_id)}</div>
+        ${t.last_summary ? `<div class="d-task-summary">${esc(t.last_summary)}</div>` : ''}
+        ${t.last_error ? `<div style="color:#c06060;font-size:8px;margin-top:2px">${esc(t.last_error)}</div>` : ''}
+        <div style="font-size:7px;color:#3a5868;margin-top:2px">Attempts: ${t.attempts||0} &middot; Deadlock recoveries: ${t.deadlock_recoveries||0}</div>
+      </div>`;
+    });
+  }
+
+  // Config
+  if (config.execution_profile || config.started_at) {
+    h += `<div class="d-section">Configuration</div>`;
+    h += `<div style="font-size:9px;color:#5a8a9a;display:grid;grid-template-columns:1fr 1fr;gap:4px">`;
+    if (config.execution_profile) h += `<div>Profile: <span style="color:#4dd8e8">${esc(config.execution_profile)}</span></div>`;
+    if (config.started_at) h += `<div>Started: <span style="color:#4dd8e8">${esc(config.started_at)}</span></div>`;
+    h += `<div>Continuous: <span style="color:#4dd8e8">${config.continuous ? 'yes' : 'no'}</span></div>`;
+    if (config.max_cycles) h += `<div>Max cycles: <span style="color:#4dd8e8">${config.max_cycles}</span></div>`;
+    h += `</div>`;
+  }
+
+  // Related alerts
+  const relAlerts = (DATA.alerts || []).filter(a => a.lane_id === lane.lane_id);
+  if (relAlerts.length > 0) {
+    h += `<div class="d-section">Active Alerts</div>`;
+    relAlerts.forEach(a => {
+      const ac = a.severity === 'high' ? '#e83030' : '#e8a800';
+      h += `<div style="padding:5px 8px;margin:2px 0;border-radius:3px;background:${a.severity==='high'?'rgba(232,48,48,0.06)':'rgba(232,168,0,0.04)'};border-left:2px solid ${ac};font-size:9px;color:${ac}">${esc(a.message||'')}</div>`;
+    });
+  }
+
+  // Related events
+  const relEvents = (DATA.events || []).filter(e => e.lane_id === lane.lane_id).slice(0, 10);
+  if (relEvents.length > 0) {
+    h += `<div class="d-section">Recent Events</div>`;
+    relEvents.forEach(e => {
+      const ts = e.timestamp ? e.timestamp.slice(11, 19) : '';
+      h += `<div style="font-size:8px;padding:3px 0;border-bottom:1px solid #0a1a2a">
+        <span style="color:#2a5060">${esc(ts)}</span>
+        <span style="color:#6a9aaa">${esc((e.message || e.summary || e.type || '').slice(0,100))}</span>
+      </div>`;
+    });
+  }
+
+  // Related git commits
+  const owner = lane.owner;
+  const relCommits = (DATA.git?.recent_commits || []).filter(c => c.author === owner).slice(0, 4);
+  if (relCommits.length > 0) {
+    h += `<div class="d-section">Recent Commits (${esc(owner)})</div>`;
+    relCommits.forEach(c => {
+      h += `<div style="font-size:8px;padding:3px 0;border-bottom:1px solid #0a1a2a">
+        <span style="color:#4dd8e8">${esc((c.short_hash || c.hash || '').slice(0,7))}</span>
+        <span style="color:#7ab0c0">${esc((c.message||'').slice(0,60))}</span>
+        <span style="color:#2a5060">${esc(c.relative_time||'')}</span>
+      </div>`;
+    });
+  }
+
+  body.innerHTML = h;
+  overlay.classList.add('open');
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// CLOCK + KEYBOARD
+// ═══════════════════════════════════════════════════════════════════
+setInterval(() => {
+  const el = document.getElementById('clock');
+  if (el) el.textContent = new Date().toISOString().slice(11, 19) + 'Z';
+}, 1000);
+
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeDetail();
+  if (e.key === 'r' && !e.ctrlKey && !e.metaKey && document.activeElement === document.body) {
+    fetchSnapshot();
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BOOT
+// ═══════════════════════════════════════════════════════════════════
+startPolling();
+</script>
+</body>
+</html>

--- a/src/orxaq_autonomy/dashboard_v2_meridian.html
+++ b/src/orxaq_autonomy/dashboard_v2_meridian.html
@@ -1,0 +1,1949 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>MERIDIAN — Swarm Intelligence Briefing</title>
+<style>
+/* ── Reset & Base ─────────────────────────────────────────────────── */
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+
+:root{
+  --bg:#faf8f5;
+  --bg-section:#ffffff;
+  --text:#1a1a1a;
+  --muted:#666666;
+  --critical:#c41e1e;
+  --warning:#8b6914;
+  --ok:#1a6b3a;
+  --link:#1a4a7a;
+  --divider:#d4cfc7;
+  --rule-light:#e8e4de;
+  --accent-cream:#f5f1eb;
+}
+
+html{
+  scroll-behavior:smooth;
+  font-size:18px;
+  -webkit-text-size-adjust:100%;
+}
+
+body{
+  font-family:Georgia,'Times New Roman',Charter,serif;
+  background:var(--bg);
+  color:var(--text);
+  line-height:1.7;
+  min-height:100vh;
+}
+
+/* ── Typography ───────────────────────────────────────────────────── */
+h1,h2,h3,h4,h5,h6{
+  font-family:Georgia,Charter,'Times New Roman',serif;
+  font-weight:400;
+  line-height:1.3;
+}
+
+.sans{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+}
+
+/* ── Layout Shell ─────────────────────────────────────────────────── */
+.page{
+  max-width:780px;
+  margin:0 auto;
+  padding:0 24px;
+}
+
+/* ── Masthead ─────────────────────────────────────────────────────── */
+.masthead{
+  text-align:center;
+  padding:40px 0 28px;
+  border-bottom:3px double var(--divider);
+}
+
+.masthead-title{
+  font-size:2rem;
+  letter-spacing:0.12em;
+  text-transform:uppercase;
+  font-weight:400;
+  margin-bottom:4px;
+  color:var(--text);
+}
+
+.masthead-subtitle{
+  font-size:0.85rem;
+  color:var(--muted);
+  letter-spacing:0.06em;
+  font-style:italic;
+}
+
+.masthead-meta{
+  display:flex;
+  justify-content:center;
+  gap:24px;
+  margin-top:14px;
+  font-size:0.72rem;
+  color:var(--muted);
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  letter-spacing:0.02em;
+}
+
+.masthead-meta .branch{
+  color:var(--link);
+}
+
+/* ── Section styles ───────────────────────────────────────────────── */
+.briefing-section{
+  padding:28px 0 24px;
+  border-bottom:1px solid var(--rule-light);
+}
+
+.briefing-section:last-of-type{
+  border-bottom:none;
+}
+
+.section-header{
+  display:flex;
+  align-items:baseline;
+  gap:12px;
+  margin-bottom:16px;
+}
+
+.section-number{
+  font-size:0.65rem;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-weight:700;
+  color:var(--muted);
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  flex-shrink:0;
+}
+
+.section-title{
+  font-size:1.3rem;
+  font-weight:400;
+  font-style:italic;
+  color:var(--text);
+}
+
+.prose{
+  font-size:1rem;
+  line-height:1.8;
+  color:var(--text);
+}
+
+.prose+.prose{
+  margin-top:12px;
+}
+
+.prose .num{
+  font-variant-numeric:tabular-nums;
+  font-weight:600;
+}
+
+.prose .critical-text{
+  color:var(--critical);
+  font-weight:600;
+}
+
+.prose .warning-text{
+  color:var(--warning);
+  font-weight:600;
+}
+
+.prose .ok-text{
+  color:var(--ok);
+}
+
+.muted-prose{
+  color:var(--muted);
+  font-size:0.88rem;
+  line-height:1.7;
+  font-style:italic;
+}
+
+/* ── Executive Summary ────────────────────────────────────────────── */
+.executive-summary{
+  padding:32px 0 28px;
+  border-bottom:1px solid var(--divider);
+}
+
+.executive-summary .lede{
+  font-size:1.15rem;
+  line-height:1.85;
+  color:var(--text);
+}
+
+.executive-summary .lede::first-line{
+  font-variant:small-caps;
+  letter-spacing:0.02em;
+}
+
+/* ── Critical Alert Block ─────────────────────────────────────────── */
+.alert-block{
+  border-left:4px solid var(--critical);
+  background:rgba(196,30,30,0.04);
+  padding:16px 20px;
+  margin:12px 0;
+  border-radius:0 4px 4px 0;
+}
+
+.alert-block .alert-label{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.65rem;
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:0.1em;
+  color:var(--critical);
+  margin-bottom:6px;
+}
+
+.alert-block .alert-prose{
+  font-size:0.95rem;
+  line-height:1.7;
+  color:var(--text);
+}
+
+.warning-block{
+  border-left:4px solid var(--warning);
+  background:rgba(139,105,20,0.04);
+  padding:16px 20px;
+  margin:12px 0;
+  border-radius:0 4px 4px 0;
+}
+
+.warning-block .alert-label{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.65rem;
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:0.1em;
+  color:var(--warning);
+  margin-bottom:6px;
+}
+
+.warning-block .alert-prose{
+  font-size:0.95rem;
+  line-height:1.7;
+  color:var(--text);
+}
+
+/* ── Owner paragraphs ─────────────────────────────────────────────── */
+.owner-brief{
+  margin-bottom:18px;
+}
+
+.owner-brief .owner-name{
+  font-variant:small-caps;
+  font-size:1.05rem;
+  letter-spacing:0.04em;
+  font-weight:600;
+}
+
+/* ── Lane Dispatches (collapsible) ────────────────────────────────── */
+details.lane-dispatch{
+  margin:8px 0;
+  border:1px solid var(--rule-light);
+  border-radius:4px;
+  background:var(--bg-section);
+  overflow:hidden;
+}
+
+details.lane-dispatch[open]{
+  border-color:var(--divider);
+}
+
+details.lane-dispatch summary{
+  cursor:pointer;
+  padding:12px 16px;
+  font-size:0.9rem;
+  line-height:1.6;
+  list-style:none;
+  display:flex;
+  align-items:center;
+  gap:10px;
+  user-select:none;
+  transition:background 0.15s;
+}
+
+details.lane-dispatch summary:hover{
+  background:var(--accent-cream);
+}
+
+details.lane-dispatch summary::-webkit-details-marker{display:none}
+
+details.lane-dispatch summary::before{
+  content:'';
+  display:inline-block;
+  width:8px;
+  height:8px;
+  border-radius:50%;
+  flex-shrink:0;
+}
+
+details.lane-dispatch[data-status="done"] summary::before{background:var(--ok)}
+details.lane-dispatch[data-status="in_progress"] summary::before{background:#2a7abf}
+details.lane-dispatch[data-status="blocked"] summary::before{background:var(--critical)}
+details.lane-dispatch[data-status="pending"] summary::before{background:var(--warning)}
+details.lane-dispatch[data-status="idle"] summary::before{background:var(--divider)}
+
+details.lane-dispatch summary .lane-id{
+  font-weight:600;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.78rem;
+  letter-spacing:0.01em;
+}
+
+details.lane-dispatch summary .lane-oneliner{
+  flex:1;
+  color:var(--muted);
+  font-size:0.82rem;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+
+details.lane-dispatch summary .lane-status-tag{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.62rem;
+  font-weight:700;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  padding:2px 8px;
+  border-radius:3px;
+  flex-shrink:0;
+}
+
+.tag-done{color:var(--ok);background:rgba(26,107,58,0.08)}
+.tag-in_progress{color:#2a7abf;background:rgba(42,122,191,0.08)}
+.tag-blocked{color:var(--critical);background:rgba(196,30,30,0.08)}
+.tag-pending{color:var(--warning);background:rgba(139,105,20,0.08)}
+.tag-idle{color:var(--muted);background:rgba(102,102,102,0.08)}
+
+details.lane-dispatch .lane-body{
+  padding:0 16px 16px;
+  border-top:1px solid var(--rule-light);
+}
+
+details.lane-dispatch .lane-body .prose{
+  font-size:0.9rem;
+  line-height:1.75;
+}
+
+details.lane-dispatch .task-list{
+  margin-top:12px;
+  padding-left:0;
+  list-style:none;
+}
+
+details.lane-dispatch .task-item{
+  padding:8px 0;
+  border-bottom:1px solid var(--rule-light);
+  font-size:0.85rem;
+  line-height:1.6;
+}
+
+details.lane-dispatch .task-item:last-child{
+  border-bottom:none;
+}
+
+details.lane-dispatch .task-item .task-id{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-weight:600;
+  font-size:0.76rem;
+}
+
+/* ── Git Narrative ────────────────────────────────────────────────── */
+.commit-entry{
+  padding:10px 0;
+  border-bottom:1px solid var(--rule-light);
+  font-size:0.9rem;
+  line-height:1.7;
+}
+
+.commit-entry:last-child{
+  border-bottom:none;
+}
+
+.commit-hash{
+  font-family:'SF Mono','Fira Code',Consolas,monospace;
+  font-size:0.75rem;
+  color:var(--link);
+  letter-spacing:0.02em;
+}
+
+.commit-author{
+  font-weight:600;
+}
+
+.commit-time{
+  color:var(--muted);
+  font-size:0.82rem;
+  font-style:italic;
+}
+
+/* ── Health Criteria ──────────────────────────────────────────────── */
+.criterion{
+  display:flex;
+  align-items:baseline;
+  gap:8px;
+  padding:5px 0;
+  font-size:0.88rem;
+  line-height:1.6;
+}
+
+.criterion-dot{
+  width:8px;
+  height:8px;
+  border-radius:50%;
+  flex-shrink:0;
+  position:relative;
+  top:1px;
+}
+
+.criterion-dot.pass{background:var(--ok)}
+.criterion-dot.fail{background:var(--critical)}
+.criterion-dot.warn{background:var(--warning)}
+.criterion-dot.unknown{background:var(--divider)}
+
+/* ── Connectivity ─────────────────────────────────────────────────── */
+.endpoint-line{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  padding:4px 0;
+  font-size:0.88rem;
+}
+
+.endpoint-dot{
+  width:7px;
+  height:7px;
+  border-radius:50%;
+  flex-shrink:0;
+}
+
+.endpoint-dot.up{background:var(--ok)}
+.endpoint-dot.down{background:var(--critical)}
+.endpoint-dot.unknown{background:var(--divider)}
+
+/* ── Footer ───────────────────────────────────────────────────────── */
+.briefing-footer{
+  padding:28px 0 40px;
+  text-align:center;
+  border-top:3px double var(--divider);
+  margin-top:8px;
+}
+
+.footer-controls{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:20px;
+  margin-bottom:16px;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.75rem;
+}
+
+.btn-refresh{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.72rem;
+  padding:6px 16px;
+  border:1px solid var(--divider);
+  border-radius:3px;
+  background:var(--bg-section);
+  color:var(--text);
+  cursor:pointer;
+  letter-spacing:0.04em;
+  text-transform:uppercase;
+  font-weight:600;
+  transition:all 0.15s;
+}
+
+.btn-refresh:hover{
+  background:var(--text);
+  color:var(--bg);
+}
+
+.auto-refresh-toggle{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  color:var(--muted);
+}
+
+.auto-refresh-toggle input[type="checkbox"]{
+  accent-color:var(--text);
+}
+
+.footer-colophon{
+  font-size:0.7rem;
+  color:var(--muted);
+  font-style:italic;
+  margin-top:8px;
+}
+
+/* ── Dashboard Navigation Links ───────────────────────────────────── */
+.dashboard-nav{
+  display:flex;
+  justify-content:center;
+  gap:16px;
+  margin-top:12px;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.7rem;
+}
+
+.dashboard-nav a{
+  color:var(--link);
+  text-decoration:none;
+  letter-spacing:0.04em;
+  text-transform:uppercase;
+  font-weight:600;
+  padding:2px 0;
+  border-bottom:1px solid transparent;
+  transition:border-color 0.15s;
+}
+
+.dashboard-nav a:hover{
+  border-bottom-color:var(--link);
+}
+
+/* ── Loading / Error States ───────────────────────────────────────── */
+.loading-state{
+  text-align:center;
+  padding:80px 0;
+  color:var(--muted);
+  font-style:italic;
+  font-size:0.95rem;
+}
+
+.error-state{
+  text-align:center;
+  padding:60px 0;
+  color:var(--critical);
+}
+
+.error-state .error-title{
+  font-size:1.1rem;
+  margin-bottom:8px;
+}
+
+.error-state .error-detail{
+  font-size:0.85rem;
+  color:var(--muted);
+  font-style:italic;
+}
+
+/* ── Empty Placeholder ────────────────────────────────────────────── */
+.empty-note{
+  font-style:italic;
+  color:var(--muted);
+  font-size:0.9rem;
+}
+
+/* ── Refresh Pulse ────────────────────────────────────────────────── */
+.refresh-indicator{
+  display:inline-block;
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:var(--ok);
+  opacity:0;
+  transition:opacity 0.3s;
+  margin-left:8px;
+  vertical-align:middle;
+}
+
+.refresh-indicator.active{
+  opacity:1;
+  animation:pulse 0.6s ease-out;
+}
+
+@keyframes pulse{
+  0%{transform:scale(1);opacity:1}
+  100%{transform:scale(2.5);opacity:0}
+}
+
+/* ── Print Styles ─────────────────────────────────────────────────── */
+@media print{
+  html{font-size:11pt}
+  body{background:#fff}
+  .footer-controls{display:none !important}
+  .dashboard-nav{display:none !important}
+  .action-callout{display:none !important}
+  .action-btn{display:none !important}
+  .confirm-modal{display:none !important}
+  #sec-actions{display:none !important}
+  details.lane-dispatch{break-inside:avoid}
+  details.lane-dispatch[open] .lane-body{display:block}
+  .briefing-section{break-inside:avoid}
+  .alert-block,.warning-block{break-inside:avoid}
+  .page{max-width:100%;padding:0}
+  .masthead{padding:20px 0 14px}
+}
+
+/* ── Action Callouts ──────────────────────────────────────────────── */
+.action-callout{
+  background:#fef3e2;
+  border-left:3px solid #d97706;
+  padding:10px 14px;
+  margin:10px 0;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.82rem;
+}
+
+.action-label{
+  display:block;
+  font-size:0.65rem;
+  font-weight:700;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:#d97706;
+  margin-bottom:4px;
+}
+
+.action-btn{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.78rem;
+  background:none;
+  border:1px solid #d4c5a9;
+  border-radius:4px;
+  padding:3px 10px;
+  cursor:pointer;
+  color:#7c3aed;
+  transition:background 0.15s;
+}
+
+.action-btn:hover{background:#f5f0e8}
+.action-btn.danger{color:#dc2626;border-color:#fca5a5}
+.action-btn.danger:hover{background:#fef2f2}
+
+/* ── Operator Actions Section ────────────────────────────────────── */
+.actions-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(200px,1fr));
+  gap:10px;
+  margin:12px 0;
+}
+
+.action-card{
+  border:1px solid var(--rule-light);
+  border-radius:4px;
+  padding:12px 14px;
+  background:var(--bg-section);
+  transition:border-color 0.15s;
+}
+
+.action-card:hover{border-color:var(--divider)}
+
+.action-card .action-card-label{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+  font-size:0.65rem;
+  font-weight:700;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:var(--muted);
+  margin-bottom:4px;
+}
+
+.action-card .action-card-desc{
+  font-size:0.82rem;
+  color:var(--text);
+  margin-bottom:8px;
+  line-height:1.5;
+}
+
+.audit-trail{
+  margin-top:16px;
+}
+
+.audit-entry{
+  padding:8px 0;
+  border-bottom:1px solid var(--rule-light);
+  font-size:0.82rem;
+  line-height:1.6;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
+}
+
+.audit-entry:last-child{border-bottom:none}
+
+.audit-action-id{
+  font-weight:600;
+  color:var(--link);
+}
+
+.audit-time{
+  color:var(--muted);
+  font-size:0.75rem;
+  font-style:italic;
+}
+
+.audit-result-ok{color:var(--ok);font-weight:600}
+.audit-result-fail{color:var(--critical);font-weight:600}
+
+/* ── Confirmation Modal ──────────────────────────────────────────── */
+.confirm-modal{
+  position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:1000;
+  display:flex;align-items:center;justify-content:center;
+}
+
+.confirm-modal-inner{
+  background:#fefcf7;
+  border:1px solid #d4c5a9;
+  border-radius:8px;
+  padding:24px;
+  max-width:500px;
+  width:90%;
+  box-shadow:0 8px 24px rgba(0,0,0,0.15);
+}
+
+.confirm-title{
+  font-family:Georgia,serif;
+  font-size:1.1rem;
+  margin:0 0 12px;
+}
+
+.confirm-buttons{
+  display:flex;
+  gap:8px;
+  margin-top:16px;
+}
+
+/* ── Responsive: single column mobile ─────────────────────────────── */
+@media(max-width:640px){
+  html{font-size:16px}
+  .page{padding:0 16px}
+  .masthead{padding:24px 0 16px}
+  .masthead-title{font-size:1.5rem;letter-spacing:0.06em}
+  .masthead-meta{flex-direction:column;gap:4px}
+  .section-title{font-size:1.1rem}
+  details.lane-dispatch summary{padding:10px 12px}
+  details.lane-dispatch .lane-body{padding:0 12px 12px}
+  .briefing-section{padding:20px 0 18px}
+  .actions-grid{grid-template-columns:1fr}
+  .confirm-modal-inner{width:95%;padding:16px}
+}
+</style>
+</head>
+<body>
+
+<div class="page" id="app">
+
+  <!-- Masthead -->
+  <header class="masthead" id="masthead">
+    <h1 class="masthead-title">MERIDIAN</h1>
+    <div class="masthead-subtitle">Swarm Intelligence Briefing</div>
+    <div class="masthead-meta">
+      <span id="meta-timestamp">Loading&hellip;</span>
+      <span id="meta-branch"></span>
+      <span id="meta-refresh-indicator"><span class="refresh-indicator" id="refresh-dot"></span></span>
+    </div>
+  </header>
+
+  <!-- Loading State -->
+  <div class="loading-state" id="loading-state">
+    <p>Establishing connection to the swarm intelligence network&hellip;</p>
+  </div>
+
+  <!-- Error State -->
+  <div class="error-state" id="error-state" style="display:none">
+    <div class="error-title">Connection Interrupted</div>
+    <div class="error-detail" id="error-detail">Unable to reach the swarm API.</div>
+  </div>
+
+  <!-- Main Content (hidden until loaded) -->
+  <main id="main-content" style="display:none">
+
+    <!-- I. Executive Summary -->
+    <section class="executive-summary" id="sec-executive">
+      <div class="lede" id="executive-summary-text"></div>
+    </section>
+
+    <!-- II. Critical Alerts -->
+    <section class="briefing-section" id="sec-alerts" style="display:none">
+      <div class="section-header">
+        <span class="section-number">II</span>
+        <h2 class="section-title">Critical Alerts</h2>
+      </div>
+      <div id="alerts-content"></div>
+    </section>
+
+    <!-- III. Fleet Status -->
+    <section class="briefing-section" id="sec-fleet">
+      <div class="section-header">
+        <span class="section-number">III</span>
+        <h2 class="section-title">Fleet Status</h2>
+      </div>
+      <div id="fleet-content"></div>
+    </section>
+
+    <!-- IV. Lane Dispatches -->
+    <section class="briefing-section" id="sec-lanes">
+      <div class="section-header">
+        <span class="section-number">IV</span>
+        <h2 class="section-title">Lane Dispatches</h2>
+      </div>
+      <div id="lanes-content"></div>
+    </section>
+
+    <!-- V. Performance Digest -->
+    <section class="briefing-section" id="sec-performance">
+      <div class="section-header">
+        <span class="section-number">V</span>
+        <h2 class="section-title">Performance Digest</h2>
+      </div>
+      <div id="performance-content"></div>
+    </section>
+
+    <!-- VI. Git Activity -->
+    <section class="briefing-section" id="sec-git">
+      <div class="section-header">
+        <span class="section-number">VI</span>
+        <h2 class="section-title">Git Activity</h2>
+      </div>
+      <div id="git-content"></div>
+    </section>
+
+    <!-- VII. Policy & Governance -->
+    <section class="briefing-section" id="sec-governance">
+      <div class="section-header">
+        <span class="section-number">VII</span>
+        <h2 class="section-title">Policy &amp; Governance</h2>
+      </div>
+      <div id="governance-content"></div>
+    </section>
+
+    <!-- VIII. Connectivity Report -->
+    <section class="briefing-section" id="sec-connectivity">
+      <div class="section-header">
+        <span class="section-number">VIII</span>
+        <h2 class="section-title">Connectivity Report</h2>
+      </div>
+      <div id="connectivity-content"></div>
+    </section>
+
+    <!-- IX. Operator Actions -->
+    <section class="briefing-section" id="sec-actions">
+      <div class="section-header">
+        <span class="section-number">IX</span>
+        <h2 class="section-title">Operator Actions</h2>
+      </div>
+      <div id="actions-content">
+        <p class="muted-prose">Loading available actions&hellip;</p>
+      </div>
+      <div class="audit-trail" id="audit-trail">
+        <p class="muted-prose" style="margin-top:16px">Loading audit trail&hellip;</p>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Confirmation Modal -->
+  <div id="confirmModal" class="confirm-modal" style="display:none">
+    <div class="confirm-modal-inner">
+      <h3 class="confirm-title">Confirm Action</h3>
+      <div id="confirmBody"></div>
+      <div class="confirm-buttons">
+        <button class="action-btn" onclick="confirmModalAction()">Confirm &amp; Execute</button>
+        <button class="action-btn" onclick="closeConfirmModal()">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="briefing-footer">
+    <div class="footer-controls" id="footer-controls">
+      <button class="btn-refresh" id="btn-refresh" title="Refresh now">Refresh Briefing</button>
+      <label class="auto-refresh-toggle sans">
+        <input type="checkbox" id="auto-refresh-toggle" checked>
+        Auto-refresh (30s)
+      </label>
+    </div>
+    <div class="dashboard-nav">
+      <a href="/nexus">Nexus</a>
+      <a href="/meridian">Meridian</a>
+      <a href="/prism">Prism</a>
+      <a href="/signal">Signal</a>
+    </div>
+    <div class="footer-colophon" id="footer-colophon">
+      MERIDIAN Swarm Intelligence Briefing
+    </div>
+  </footer>
+
+</div>
+
+<script>
+/* ═══════════════════════════════════════════════════════════════════════
+   MERIDIAN — Swarm Intelligence Briefing
+   Text-first editorial dashboard. Zero external dependencies.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+(function() {
+'use strict';
+
+/* ── Utility: HTML Escaping ───────────────────────────────────────── */
+const ESC_MAP = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+function esc(s) {
+  if (s == null) return '';
+  return String(s).replace(/[&<>"']/g, c => ESC_MAP[c]);
+}
+
+/* ── Utility: Number Formatting ───────────────────────────────────── */
+function fmtNum(n) {
+  if (n == null || isNaN(n)) return '0';
+  return Number(n).toLocaleString('en-US');
+}
+
+function fmtCost(n) {
+  if (n == null || isNaN(n)) return '$0.00';
+  return '$' + Number(n).toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
+}
+
+function fmtPct(n) {
+  if (n == null || isNaN(n)) return '0%';
+  return Number(n).toFixed(1) + '%';
+}
+
+function fmtDuration(seconds) {
+  if (seconds == null || isNaN(seconds) || seconds < 0) return 'unknown';
+  if (seconds < 60) return Math.round(seconds) + ' seconds';
+  if (seconds < 3600) return Math.round(seconds / 60) + ' minutes';
+  if (seconds < 86400) return (seconds / 3600).toFixed(1) + ' hours';
+  return (seconds / 86400).toFixed(1) + ' days';
+}
+
+function fmtTimestamp(iso) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString('en-US', {
+      weekday:'long', year:'numeric', month:'long', day:'numeric',
+      hour:'2-digit', minute:'2-digit', second:'2-digit', timeZoneName:'short'
+    });
+  } catch(e) { return esc(iso); }
+}
+
+function fmtTime(iso) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('en-US', {hour:'2-digit', minute:'2-digit'});
+  } catch(e) { return esc(iso); }
+}
+
+function pluralize(n, singular, plural) {
+  plural = plural || (singular + 's');
+  return n === 1 ? singular : plural;
+}
+
+/* ── Utility: Status to human-readable ────────────────────────────── */
+function statusLabel(s) {
+  const map = {
+    done:'completed', in_progress:'active', blocked:'blocked',
+    pending:'pending', idle:'idle'
+  };
+  return map[s] || s;
+}
+
+function statusCssClass(s) {
+  if (s === 'blocked') return 'critical-text';
+  if (s === 'done') return 'ok-text';
+  if (s === 'in_progress') return '';
+  if (s === 'pending') return 'warning-text';
+  return '';
+}
+
+/* ── Utility: Owner name formatting ───────────────────────────────── */
+function ownerDisplay(owner) {
+  if (!owner) return 'Unknown';
+  return owner.charAt(0).toUpperCase() + owner.slice(1);
+}
+
+/* ── Natural Language: Executive Summary ──────────────────────────── */
+function generateExecutiveSummary(snapshot) {
+  const s = snapshot.summary || {};
+  const lanes = s.lanes_total || 0;
+  const owners = Object.keys(s.owner_counts || {});
+  const ownerCount = owners.length;
+  const statusCounts = s.status_counts || {};
+  const blocked = statusCounts.blocked || 0;
+  const done = statusCounts.done || 0;
+  const active = statusCounts.in_progress || 0;
+  const pending = statusCounts.pending || 0;
+  const cost = s.total_cost_usd || 0;
+  const responses = s.total_responses || 0;
+  const alerts = s.alerts_count || 0;
+
+  const parts = [];
+
+  // Opening sentence
+  const ownerNames = owners.map(ownerDisplay).join(', ');
+  parts.push(
+    `The swarm is operating <span class="num">${fmtNum(lanes)}</span> ${pluralize(lanes,'lane')}` +
+    ` across <span class="num">${ownerCount}</span> agent ${pluralize(ownerCount,'family','families')}` +
+    (ownerCount > 0 ? ` (${esc(ownerNames)})` : '') + '.'
+  );
+
+  // Status breakdown
+  const statusParts = [];
+  if (done > 0) statusParts.push(`<span class="num">${done}</span> ${pluralize(done,'lane')} completed`);
+  if (active > 0) statusParts.push(`<span class="num">${active}</span> currently active`);
+  if (pending > 0) statusParts.push(`<span class="num">${pending}</span> pending`);
+  if (blocked > 0) statusParts.push(`<span class="num critical-text">${blocked}</span> <span class="critical-text">blocked</span>`);
+  if (statusParts.length > 0) {
+    parts.push(statusParts.join(', ') + '.');
+  }
+
+  // Cost
+  if (cost > 0 || responses > 0) {
+    parts.push(
+      `Total cost stands at <span class="num">${fmtCost(cost)}</span>` +
+      ` across <span class="num">${fmtNum(responses)}</span> ${pluralize(responses,'response')}.`
+    );
+  }
+
+  // Alerts
+  if (alerts > 0) {
+    const highAlerts = (snapshot.alerts || []).filter(a => a.severity === 'high');
+    const medAlerts = (snapshot.alerts || []).filter(a => a.severity === 'medium');
+    let alertStr = `<span class="num ${alerts > 5 ? 'warning-text' : ''}">${alerts}</span> ${pluralize(alerts,'alert')} ${pluralize(alerts,'requires','require')} attention`;
+    if (highAlerts.length > 0) {
+      alertStr += `, with <span class="num critical-text">${highAlerts.length}</span> at critical severity`;
+    }
+    parts.push(alertStr + '.');
+  } else {
+    parts.push('No alerts are pending at this time.');
+  }
+
+  return parts.join(' ');
+}
+
+/* ── Natural Language: Critical Alerts ────────────────────────────── */
+function generateAlertBlocks(alerts) {
+  if (!alerts || alerts.length === 0) return '';
+  const highAlerts = alerts.filter(a => a.severity === 'high');
+  const medAlerts = alerts.filter(a => a.severity === 'medium');
+  let html = '';
+
+  if (highAlerts.length > 0) {
+    for (const alert of highAlerts) {
+      html += `<div class="alert-block">`;
+      html += `<div class="alert-label">${esc(alert.type || 'Alert').replace(/_/g, ' ')}</div>`;
+      html += `<div class="alert-prose">${generateAlertProse(alert)}</div>`;
+      html += `</div>`;
+    }
+  }
+
+  if (medAlerts.length > 0) {
+    // Group medium alerts by type
+    const byType = {};
+    for (const a of medAlerts) {
+      const t = a.type || 'unknown';
+      if (!byType[t]) byType[t] = [];
+      byType[t].push(a);
+    }
+
+    for (const [type, group] of Object.entries(byType)) {
+      html += `<div class="warning-block">`;
+      html += `<div class="alert-label">${esc(type.replace(/_/g, ' '))} (${group.length})</div>`;
+      if (group.length <= 3) {
+        for (const a of group) {
+          html += `<div class="alert-prose">${generateAlertProse(a)}</div>`;
+        }
+      } else {
+        const lanes = group.map(a => esc(a.lane_id || 'unknown'));
+        html += `<div class="alert-prose">${fmtNum(group.length)} lanes affected: ${lanes.join(', ')}.</div>`;
+      }
+      html += `</div>`;
+    }
+  }
+
+  return html;
+}
+
+function generateAlertProse(alert) {
+  const laneId = esc(alert.lane_id || 'unknown');
+  const type = alert.type || '';
+
+  if (type === 'blocked_lane') {
+    return `Lane <strong>${laneId}</strong> is currently blocked and unable to make progress. Immediate investigation is required.`;
+  }
+  if (type === 'stale_heartbeat') {
+    return `Lane <strong>${laneId}</strong> has not reported a heartbeat recently. ${esc(alert.message || '')}`;
+  }
+  if (type === 'deadlock_storm') {
+    return `${esc(alert.message || '')} in lane <strong>${laneId}</strong>. The task is experiencing repeated deadlock recovery attempts.`;
+  }
+  return esc(alert.message || 'No details available.');
+}
+
+/* ── Natural Language: Fleet Status ───────────────────────────────── */
+function generateFleetStatus(snapshot) {
+  const lanes = snapshot.lanes || [];
+  const ownerCounts = snapshot.summary?.owner_counts || {};
+
+  if (Object.keys(ownerCounts).length === 0) {
+    return '<p class="empty-note">No agent families are currently registered in the fleet.</p>';
+  }
+
+  let html = '';
+  for (const [owner, count] of Object.entries(ownerCounts)) {
+    const ownerLanes = lanes.filter(l => l.owner === owner);
+    const done = ownerLanes.filter(l => l.status === 'done').length;
+    const active = ownerLanes.filter(l => l.status === 'in_progress').length;
+    const blocked = ownerLanes.filter(l => l.status === 'blocked').length;
+    const pending = ownerLanes.filter(l => l.status === 'pending').length;
+    const idle = ownerLanes.filter(l => l.status === 'idle').length;
+
+    const totalCost = ownerLanes.reduce((s,l) => s + (l.metrics?.cost_usd_total || 0), 0);
+    const totalResponses = ownerLanes.reduce((s,l) => s + (l.metrics?.responses_total || 0), 0);
+    const totalTokens = ownerLanes.reduce((s,l) => s + (l.metrics?.tokens_total || 0), 0);
+
+    html += `<div class="owner-brief"><p class="prose">`;
+    html += `<span class="owner-name">${esc(ownerDisplay(owner))}</span> commands `;
+    html += `<span class="num">${count}</span> ${pluralize(count,'lane')}: `;
+
+    const statusFragments = [];
+    if (done > 0) statusFragments.push(`<span class="num">${done}</span> completed`);
+    if (active > 0) statusFragments.push(`<span class="num">${active}</span> active`);
+    if (pending > 0) statusFragments.push(`<span class="num">${pending}</span> pending`);
+    if (blocked > 0) statusFragments.push(`<span class="num critical-text">${blocked}</span> <span class="critical-text">blocked</span>`);
+    if (idle > 0) statusFragments.push(`<span class="num">${idle}</span> idle`);
+    html += statusFragments.join(', ');
+
+    html += `. This family has accumulated <span class="num">${fmtCost(totalCost)}</span> in cost`;
+    html += ` across <span class="num">${fmtNum(totalResponses)}</span> ${pluralize(totalResponses,'response')}`;
+    if (totalTokens > 0) {
+      html += ` consuming <span class="num">${fmtNum(totalTokens)}</span> tokens`;
+    }
+    html += '.';
+    html += `</p></div>`;
+  }
+  return html;
+}
+
+/* ── Natural Language: Lane Dispatch ──────────────────────────────── */
+function generateLaneDispatches(lanes) {
+  if (!lanes || lanes.length === 0) {
+    return '<p class="empty-note">No lane dispatches to report.</p>';
+  }
+
+  // Sort: blocked first, then active, pending, idle, done
+  const order = {blocked:0, in_progress:1, pending:2, idle:3, done:4};
+  const sorted = [...lanes].sort((a,b) =>
+    (order[a.status] ?? 5) - (order[b.status] ?? 5)
+  );
+
+  let html = '';
+  html += `<p class="muted-prose" style="margin-bottom:12px">`;
+  html += `${fmtNum(lanes.length)} lanes reported. Select any lane for its full dispatch.`;
+  html += `</p>`;
+
+  for (const lane of sorted) {
+    const id = esc(lane.lane_id);
+    const status = lane.status || 'unknown';
+    const tc = lane.task_counts || {};
+    const totalTasks = (tc.done||0)+(tc.in_progress||0)+(tc.pending||0)+(tc.blocked||0);
+    const hb = lane.heartbeat || {};
+    const metrics = lane.metrics || {};
+
+    // One-liner for summary
+    const oneliner = `${tc.done||0}/${totalTasks} tasks, cycle ${hb.cycle||0}`;
+
+    html += `<details class="lane-dispatch" data-status="${esc(status)}">`;
+    html += `<summary>`;
+    html += `<span class="lane-id">${id}</span>`;
+    html += `<span class="lane-oneliner">${esc(oneliner)}</span>`;
+    html += `<span class="lane-status-tag tag-${esc(status)}">${esc(statusLabel(status))}</span>`;
+    html += `</summary>`;
+    html += `<div class="lane-body">`;
+    html += generateSingleLaneDispatch(lane);
+    html += `</div>`;
+    html += `</details>`;
+  }
+
+  return html;
+}
+
+function generateSingleLaneDispatch(lane) {
+  const id = esc(lane.lane_id);
+  const status = lane.status || 'unknown';
+  const tc = lane.task_counts || {};
+  const totalTasks = (tc.done||0)+(tc.in_progress||0)+(tc.pending||0)+(tc.blocked||0);
+  const hb = lane.heartbeat || {};
+  const metrics = lane.metrics || {};
+  const config = lane.config || {};
+
+  let html = '';
+
+  // Main dispatch prose
+  html += `<p class="prose">`;
+  html += `Lane <strong>${id}</strong> is currently <span class="${statusCssClass(status)}">${statusLabel(status)}</span>. `;
+
+  if (totalTasks > 0) {
+    html += `It has completed <span class="num">${tc.done||0}</span> of <span class="num">${totalTasks}</span> ${pluralize(totalTasks,'task')}`;
+    if (hb.cycle > 0) {
+      html += ` over <span class="num">${fmtNum(hb.cycle)}</span> ${pluralize(hb.cycle,'cycle')}`;
+    }
+    if (metrics.cost_usd_total > 0) {
+      html += ` at a cost of <span class="num">${fmtCost(metrics.cost_usd_total)}</span>`;
+    }
+    html += '. ';
+  }
+
+  if (tc.blocked > 0) {
+    html += `<span class="critical-text"><span class="num">${tc.blocked}</span> ${pluralize(tc.blocked,'task')} ${pluralize(tc.blocked,'is','are')} blocked.</span> `;
+  }
+
+  if (tc.in_progress > 0) {
+    html += `<span class="num">${tc.in_progress}</span> ${pluralize(tc.in_progress,'task')} ${pluralize(tc.in_progress,'is','are')} currently in progress. `;
+  }
+
+  // Heartbeat
+  if (hb.age_sec != null && hb.age_sec >= 0) {
+    html += `Last heartbeat was <span class="num">${fmtDuration(hb.age_sec)}</span> ago`;
+    if (hb.phase) {
+      html += ` in the <em>${esc(hb.phase)}</em> phase`;
+    }
+    html += '. ';
+  }
+
+  // Performance
+  if (metrics.responses_total > 0) {
+    html += `The lane has generated <span class="num">${fmtNum(metrics.responses_total)}</span> ${pluralize(metrics.responses_total,'response')}`;
+    if (metrics.first_time_pass_rate > 0) {
+      html += ` with a first-time pass rate of <span class="num">${fmtPct(metrics.first_time_pass_rate)}</span>`;
+    }
+    html += '. ';
+  }
+
+  // Config note
+  if (config.continuous) {
+    html += 'This is a continuous lane. ';
+  } else if (config.max_cycles > 0) {
+    html += `Configured for up to <span class="num">${config.max_cycles}</span> cycles. `;
+  }
+
+  html += `</p>`;
+
+  // Lane-level action callout for blocked lanes
+  if (status === 'blocked') {
+    html += `<div class="action-callout">`;
+    html += `<span class="action-label">Lane Blocked &mdash; Intervention Available</span>`;
+    html += `<p>Lane <strong>${id}</strong> requires operator attention. `;
+    html += `<button class="action-btn" onclick="doAction('lane.unblock',{lane_id:'${id}'})">Unblock Lane</button>`;
+    html += ` or `;
+    html += `<button class="action-btn" onclick="doAction('lane.restart',{lane_id:'${id}'})">Restart Lane</button>`;
+    html += `</p></div>`;
+  }
+
+  // Task details
+  const tasks = lane.tasks || [];
+  if (tasks.length > 0) {
+    html += `<ul class="task-list">`;
+    for (const task of tasks) {
+      html += `<li class="task-item">`;
+      html += `<span class="task-id">${esc(task.task_id)}</span>`;
+      html += ` &mdash; <span class="${statusCssClass(task.status)}">${esc(statusLabel(task.status))}</span>`;
+      if (task.attempts > 0) {
+        html += ` (${task.attempts} ${pluralize(task.attempts,'attempt')})`;
+      }
+      if (task.deadlock_recoveries > 0) {
+        html += `, <span class="warning-text">${task.deadlock_recoveries} deadlock ${pluralize(task.deadlock_recoveries,'recovery','recoveries')}</span>`;
+      }
+      if (task.last_summary) {
+        html += `<br><span style="color:var(--muted);font-size:0.82rem;font-style:italic">${esc(task.last_summary)}</span>`;
+      }
+      if (task.last_error) {
+        html += `<br><span style="color:var(--critical);font-size:0.82rem">${esc(task.last_error)}</span>`;
+      }
+      // Contextual action callouts for blocked/errored tasks
+      if (task.status === 'blocked' || task.last_error) {
+        const tid = esc(task.task_id);
+        html += `<div class="action-callout">`;
+        html += `<span class="action-label">Intervention Available</span>`;
+        html += `<p>This task has been blocked`;
+        if (task.attempts > 0) {
+          html += ` for ${task.attempts} ${pluralize(task.attempts,'attempt')}`;
+        }
+        html += `. <button class="action-btn" onclick="doAction('task.clear-error',{task_id:'${tid}'})">Clear Error &amp; Retry</button>`;
+        html += ` or `;
+        html += `<button class="action-btn" onclick="doAction('task.update-status',{task_id:'${tid}',new_status:'pending'})">Force Pending</button>`;
+        html += `</p></div>`;
+      }
+      html += `</li>`;
+    }
+    html += `</ul>`;
+  }
+
+  return html;
+}
+
+/* ── Natural Language: Performance Digest ─────────────────────────── */
+function generatePerformanceDigest(snapshot, costSeries) {
+  const metrics = snapshot.metrics?.global || {};
+  const lanes = snapshot.lanes || [];
+  const summary = snapshot.summary || {};
+
+  let html = '';
+
+  // Cost overview
+  const totalCost = summary.total_cost_usd || 0;
+  const totalResponses = summary.total_responses || 0;
+  const totalTokens = summary.total_tokens || 0;
+
+  html += `<p class="prose">`;
+  html += `The swarm has expended <span class="num">${fmtCost(totalCost)}</span> in total compute cost `;
+  html += `across <span class="num">${fmtNum(totalResponses)}</span> ${pluralize(totalResponses,'API response')}. `;
+  if (totalTokens > 0) {
+    html += `Total token consumption stands at <span class="num">${fmtNum(totalTokens)}</span>. `;
+  }
+  if (totalResponses > 0 && totalCost > 0) {
+    const avgCostPerResponse = totalCost / totalResponses;
+    html += `Average cost per response is <span class="num">${fmtCost(avgCostPerResponse)}</span>. `;
+  }
+  html += `</p>`;
+
+  // Pass rates
+  const ftpr = metrics.first_time_pass_rate;
+  const apr = metrics.acceptance_pass_rate;
+  if (ftpr != null || apr != null) {
+    html += `<p class="prose">`;
+    if (ftpr != null) {
+      const ftprClass = ftpr < 50 ? 'critical-text' : ftpr < 70 ? 'warning-text' : 'ok-text';
+      html += `First-time pass rate stands at <span class="num ${ftprClass}">${fmtPct(ftpr)}</span>`;
+      if (ftpr < 60) {
+        html += ', which falls below the 60% target';
+      }
+      html += '. ';
+    }
+    if (apr != null) {
+      html += `Acceptance pass rate is <span class="num">${fmtPct(apr)}</span>. `;
+    }
+    html += `</p>`;
+  }
+
+  // Latency
+  const latencies = lanes
+    .map(l => l.metrics?.latency_sec_avg)
+    .filter(v => v != null && v > 0);
+  if (latencies.length > 0) {
+    const avgLatency = latencies.reduce((a,b) => a+b, 0) / latencies.length;
+    const maxLatency = Math.max(...latencies);
+    html += `<p class="prose">`;
+    html += `Average response latency across the fleet is <span class="num">${avgLatency.toFixed(1)}</span> seconds. `;
+    if (maxLatency > avgLatency * 1.5) {
+      html += `The slowest lane averages <span class="num">${maxLatency.toFixed(1)}</span> seconds. `;
+    }
+    html += `</p>`;
+  }
+
+  // Cost series trends
+  if (costSeries) {
+    const windows = costSeries.windows || {};
+    const byProvider = costSeries.by_provider || {};
+    const windowParts = [];
+    if (windows.last_1h != null) windowParts.push(`<span class="num">${fmtCost(windows.last_1h)}</span> in the last hour`);
+    if (windows.last_24h != null) windowParts.push(`<span class="num">${fmtCost(windows.last_24h)}</span> in the last 24 hours`);
+    if (windows.last_7d != null) windowParts.push(`<span class="num">${fmtCost(windows.last_7d)}</span> over the past week`);
+    if (windowParts.length > 0) {
+      html += `<p class="prose">Cost breakdown by window: ${windowParts.join(', ')}.</p>`;
+    }
+    const providerEntries = Object.entries(byProvider);
+    if (providerEntries.length > 0) {
+      html += `<p class="prose">By provider: `;
+      html += providerEntries.map(([k,v]) => `${esc(k)} at ${fmtCost(v)}`).join(', ');
+      html += '.</p>';
+    }
+  }
+
+  if (html === '') {
+    html = '<p class="empty-note">No performance data is currently available.</p>';
+  }
+
+  return html;
+}
+
+/* ── Natural Language: Git Activity ───────────────────────────────── */
+function generateGitActivity(git) {
+  if (!git || (!git.recent_commits?.length && !git.current_branch)) {
+    return '<p class="empty-note">No git activity data is available at this time.</p>';
+  }
+
+  let html = '';
+
+  // Branch context
+  if (git.current_branch) {
+    html += `<p class="prose">The repository is currently on branch <strong>${esc(git.current_branch)}</strong>`;
+    if (git.branch_count > 0) {
+      html += ` (one of <span class="num">${fmtNum(git.branch_count)}</span> total ${pluralize(git.branch_count,'branch','branches')})`;
+    }
+    html += `.</p>`;
+  }
+
+  // Commits
+  const commits = git.recent_commits || [];
+  if (commits.length > 0) {
+    // Group by author
+    const byAuthor = {};
+    for (const c of commits) {
+      const a = c.author || 'Unknown';
+      if (!byAuthor[a]) byAuthor[a] = [];
+      byAuthor[a].push(c);
+    }
+
+    const authorCount = Object.keys(byAuthor).length;
+    html += `<p class="prose">The most recent <span class="num">${commits.length}</span> ${pluralize(commits.length,'commit')} `;
+    html += `span <span class="num">${authorCount}</span> ${pluralize(authorCount,'author')}.</p>`;
+
+    // Individual commits
+    for (const commit of commits) {
+      html += `<div class="commit-entry">`;
+      html += `<span class="commit-hash">${esc(commit.short_hash)}</span> `;
+      html += `<span class="commit-author">${esc(commit.author)}</span>: `;
+      html += `${esc(commit.message)} `;
+      html += `<span class="commit-time">&mdash; ${esc(commit.relative_time)}</span>`;
+      html += `</div>`;
+    }
+  } else {
+    html += '<p class="empty-note">No recent commits found.</p>';
+  }
+
+  return html;
+}
+
+/* ── Natural Language: Policy & Governance ─────────────────────────── */
+function generateGovernance(report, policies, privileges) {
+  let html = '';
+
+  // Health criteria from report
+  const cycleReport = report?.cycle_report || {};
+  const criteria = cycleReport.criteria || cycleReport.health_criteria || [];
+  const fullReport = report?.full_report || {};
+  const fullCriteria = fullReport.criteria || fullReport.health_criteria || [];
+  const allCriteria = criteria.length > 0 ? criteria : fullCriteria;
+
+  if (allCriteria.length > 0) {
+    const passed = allCriteria.filter(c => c.passed || c.status === 'pass').length;
+    const failed = allCriteria.filter(c => c.passed === false || c.status === 'fail').length;
+    const total = allCriteria.length;
+
+    html += `<p class="prose">`;
+    html += `Of <span class="num">${total}</span> health ${pluralize(total,'criterion','criteria')}, `;
+    html += `<span class="num ok-text">${passed}</span> ${pluralize(passed,'passes','pass')} and `;
+    if (failed > 0) {
+      html += `<span class="num critical-text">${failed}</span> ${pluralize(failed,'fails','fail')}`;
+    } else {
+      html += `none fail`;
+    }
+    html += '.</p>';
+
+    for (const c of allCriteria) {
+      const pass = c.passed || c.status === 'pass';
+      const dotClass = pass ? 'pass' : (c.status === 'warn' ? 'warn' : 'fail');
+      html += `<div class="criterion">`;
+      html += `<span class="criterion-dot ${dotClass}"></span>`;
+      html += `<span>${esc(c.name || c.label || c.id || 'Unnamed criterion')}`;
+      if (c.detail || c.message) {
+        html += ` &mdash; <span style="color:var(--muted);font-style:italic">${esc(c.detail || c.message)}</span>`;
+      }
+      html += `</span>`;
+      html += `</div>`;
+    }
+  } else {
+    // Try to extract from other structure
+    const healthData = fullReport.health || cycleReport.health;
+    if (healthData && typeof healthData === 'object') {
+      html += '<p class="prose">Health criteria summary:</p>';
+      for (const [key, val] of Object.entries(healthData)) {
+        const pass = val === true || val === 'pass' || val?.passed === true;
+        const dotClass = pass ? 'pass' : 'fail';
+        html += `<div class="criterion">`;
+        html += `<span class="criterion-dot ${dotClass}"></span>`;
+        html += `<span>${esc(key.replace(/_/g, ' '))}</span>`;
+        html += `</div>`;
+      }
+    } else {
+      html += '<p class="empty-note">No health criteria data available in the current report.</p>';
+    }
+  }
+
+  // Policies
+  const policyData = policies?.policies || {};
+  const policyKeys = Object.keys(policyData);
+  if (policyKeys.length > 0) {
+    html += `<p class="prose" style="margin-top:16px">`;
+    html += `<span class="num">${policyKeys.length}</span> ${pluralize(policyKeys.length,'policy','policies')} are under active monitoring: `;
+    const policyDescs = [];
+    for (const key of policyKeys) {
+      const p = policyData[key];
+      const compliant = p.compliant || p.healthy || p.status === 'ok' || p.status === 'pass';
+      const label = esc(key.replace(/_/g, ' '));
+      if (compliant) {
+        policyDescs.push(`${label} (<span class="ok-text">compliant</span>)`);
+      } else {
+        policyDescs.push(`${label} (<span class="critical-text">non-compliant</span>)`);
+      }
+    }
+    html += policyDescs.join(', ') + '.</p>';
+  }
+
+  // Privileges
+  if (privileges) {
+    const current = privileges.current || {};
+    const escalations = privileges.recent_escalations || [];
+    if (Object.keys(current).length > 0 || escalations.length > 0) {
+      html += `<p class="prose" style="margin-top:16px">`;
+      const level = current.level || current.privilege_level || 'standard';
+      html += `Current privilege level: <strong>${esc(level)}</strong>. `;
+      if (escalations.length > 0) {
+        html += `There have been <span class="num">${escalations.length}</span> recent privilege ${pluralize(escalations.length,'escalation')}.`;
+      }
+      html += `</p>`;
+    }
+  }
+
+  if (html === '') {
+    html = '<p class="empty-note">No governance data is currently available.</p>';
+  }
+
+  return html;
+}
+
+/* ── Natural Language: Connectivity Report ─────────────────────────── */
+function generateConnectivity(connectivity) {
+  if (!connectivity || Object.keys(connectivity).length === 0) {
+    return '<p class="empty-note">No connectivity data is available at this time.</p>';
+  }
+
+  let html = '';
+
+  // Try to find endpoint data
+  const endpoints = connectivity.endpoints || connectivity.models || connectivity;
+  if (typeof endpoints === 'object' && !Array.isArray(endpoints)) {
+    const entries = Object.entries(endpoints).filter(([k]) =>
+      k !== 'timestamp' && k !== 'checked_at'
+    );
+
+    if (entries.length === 0) {
+      return '<p class="empty-note">No model endpoints registered for monitoring.</p>';
+    }
+
+    const upCount = entries.filter(([,v]) => {
+      if (typeof v === 'boolean') return v;
+      if (typeof v === 'object') return v.status === 'up' || v.reachable === true || v.ok === true;
+      return v === 'up';
+    }).length;
+    const downCount = entries.length - upCount;
+
+    html += `<p class="prose">`;
+    html += `Monitoring <span class="num">${entries.length}</span> model ${pluralize(entries.length,'endpoint')}: `;
+    html += `<span class="num ok-text">${upCount}</span> reachable`;
+    if (downCount > 0) {
+      html += `, <span class="num critical-text">${downCount}</span> unreachable`;
+    }
+    html += '.</p>';
+
+    for (const [name, val] of entries) {
+      let isUp = false;
+      let detail = '';
+      if (typeof val === 'boolean') {
+        isUp = val;
+      } else if (typeof val === 'object' && val !== null) {
+        isUp = val.status === 'up' || val.reachable === true || val.ok === true;
+        if (val.latency_ms != null) detail = `${val.latency_ms}ms`;
+        if (val.error) detail = esc(val.error);
+      } else {
+        isUp = val === 'up';
+      }
+
+      html += `<div class="endpoint-line">`;
+      html += `<span class="endpoint-dot ${isUp ? 'up' : 'down'}"></span>`;
+      html += `<span>${esc(name)}`;
+      if (detail) {
+        html += ` <span style="color:var(--muted);font-size:0.8rem;font-style:italic">(${detail})</span>`;
+      }
+      html += `</span>`;
+      html += `</div>`;
+    }
+  } else {
+    html = '<p class="empty-note">Connectivity data format is not recognized.</p>';
+  }
+
+  return html;
+}
+
+/* ── Operator Actions: Execution & UI ─────────────────────────────── */
+let pendingConfirm = null;
+
+async function doAction(actionId, params = {}) {
+  const def = Actions.catalog?.find(a => a.action_id === actionId);
+  if (def && def.requires_confirmation) {
+    // Two-phase: preview first
+    const preview = await Actions.execute(actionId, params, { dryRun: true });
+    if (!preview.ok && !preview.confirm_token) {
+      alert('Action failed: ' + preview.message);
+      return;
+    }
+    pendingConfirm = { actionId, params, token: preview.confirm_token };
+    document.getElementById('confirmBody').innerHTML =
+      '<p>' + esc(preview.message) + '</p>' +
+      '<pre style="font-size:0.75rem;background:#f5f0e8;padding:8px;border-radius:4px;overflow:auto;max-height:200px">' +
+      esc(JSON.stringify(preview.detail, null, 2)) + '</pre>';
+    document.getElementById('confirmModal').style.display = 'flex';
+  } else {
+    // Low risk - execute directly
+    const result = await Actions.execute(actionId, params);
+    if (result.ok) {
+      // Show brief success indicator, refresh data
+      fetchAll().then(render);
+      renderAuditTrail();
+    } else {
+      alert('Action failed: ' + result.message);
+    }
+  }
+}
+
+async function confirmModalAction() {
+  if (!pendingConfirm) return;
+  const result = await Actions.execute(
+    pendingConfirm.actionId, pendingConfirm.params,
+    { confirmToken: pendingConfirm.token });
+  closeConfirmModal();
+  if (result.ok) {
+    fetchAll().then(render);
+    renderAuditTrail();
+  } else {
+    alert('Action failed: ' + result.message);
+  }
+}
+
+function closeConfirmModal() {
+  document.getElementById('confirmModal').style.display = 'none';
+  pendingConfirm = null;
+}
+
+/* ── Operator Actions: Section Rendering ─────────────────────────── */
+function renderOperatorActions() {
+  const el = document.getElementById('actions-content');
+  if (!Actions.catalog || !Array.isArray(Actions.catalog) || Actions.catalog.length === 0) {
+    el.innerHTML = '<p class="empty-note">No operator actions are currently available from the catalog.</p>';
+    return;
+  }
+
+  let html = '';
+  html += '<p class="prose">There ' +
+    (Actions.catalog.length === 1 ? 'is' : 'are') +
+    ' <span class="num">' + Actions.catalog.length + '</span> ' +
+    pluralize(Actions.catalog.length, 'action') +
+    ' available in the operator catalog.</p>';
+
+  // Quick-access buttons for common operations
+  const quickActions = [
+    { id: 'git.heal-locks', label: 'Heal Git Locks', desc: 'Clear stale git lock files across the workspace' },
+    { id: 'runner.ensure', label: 'Ensure Runner', desc: 'Verify and restart the task runner if needed' },
+    { id: 'lane.rebalance', label: 'Rebalance Lanes', desc: 'Redistribute tasks across available lanes' },
+    { id: 'task.clear-all-errors', label: 'Clear All Errors', desc: 'Reset error state on all blocked tasks', danger: true },
+  ];
+
+  const availableQuick = quickActions.filter(qa =>
+    Actions.catalog.some(a => a.action_id === qa.id)
+  );
+
+  if (availableQuick.length > 0) {
+    html += '<div class="actions-grid">';
+    for (const qa of availableQuick) {
+      html += '<div class="action-card">';
+      html += '<div class="action-card-label">' + esc(qa.label) + '</div>';
+      html += '<div class="action-card-desc">' + esc(qa.desc) + '</div>';
+      html += '<button class="action-btn' + (qa.danger ? ' danger' : '') +
+        '" onclick="doAction(\'' + esc(qa.id) + '\')">' + esc(qa.label) + '</button>';
+      html += '</div>';
+    }
+    html += '</div>';
+  }
+
+  // Full catalog listing
+  html += '<details style="margin-top:12px"><summary style="cursor:pointer;font-size:0.82rem;color:var(--muted);font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Helvetica,Arial,sans-serif;letter-spacing:0.02em">View full action catalog</summary>';
+  html += '<div style="padding:8px 0">';
+  for (const action of Actions.catalog) {
+    const risk = action.risk_level || 'low';
+    const riskClass = risk === 'high' ? 'critical-text' : risk === 'medium' ? 'warning-text' : '';
+    html += '<div style="padding:6px 0;border-bottom:1px solid var(--rule-light);font-size:0.82rem">';
+    html += '<strong class="sans" style="font-size:0.78rem">' + esc(action.action_id) + '</strong>';
+    if (riskClass) {
+      html += ' <span class="' + riskClass + '" style="font-size:0.7rem;text-transform:uppercase">[' + esc(risk) + ']</span>';
+    }
+    if (action.description) {
+      html += ' &mdash; ' + esc(action.description);
+    }
+    html += ' <button class="action-btn' + (risk === 'high' ? ' danger' : '') +
+      '" onclick="doAction(\'' + esc(action.action_id) + '\')">Execute</button>';
+    html += '</div>';
+  }
+  html += '</div></details>';
+
+  el.innerHTML = html;
+}
+
+async function renderAuditTrail() {
+  const el = document.getElementById('audit-trail');
+  try {
+    const r = await fetch('/api/v2/actions/audit');
+    if (!r.ok) {
+      el.innerHTML = '<p class="muted-prose" style="margin-top:16px"><em>Audit trail unavailable.</em></p>';
+      return;
+    }
+    const entries = await r.json();
+    if (!Array.isArray(entries) || entries.length === 0) {
+      el.innerHTML = '<p class="muted-prose" style="margin-top:16px">No actions have been executed recently.</p>';
+      return;
+    }
+
+    const recent = entries.slice(0, 5);
+    let html = '<div style="margin-top:16px">';
+    html += '<div class="section-header" style="margin-bottom:8px">';
+    html += '<span class="section-number">Audit Trail</span>';
+    html += '</div>';
+    for (const entry of recent) {
+      html += '<div class="audit-entry">';
+      html += '<span class="audit-action-id">' + esc(entry.action_id || entry.action) + '</span>';
+      if (entry.timestamp || entry.executed_at) {
+        html += ' <span class="audit-time">' + fmtTime(entry.timestamp || entry.executed_at) + '</span>';
+      }
+      const ok = entry.success !== false && entry.result !== 'error';
+      html += ' &mdash; <span class="' + (ok ? 'audit-result-ok' : 'audit-result-fail') + '">' +
+        (ok ? 'success' : 'failed') + '</span>';
+      if (entry.operator || entry.user) {
+        html += ' by ' + esc(entry.operator || entry.user);
+      }
+      if (entry.message) {
+        html += '<br><span style="color:var(--muted);font-size:0.75rem;font-style:italic">' + esc(entry.message) + '</span>';
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+    el.innerHTML = html;
+  } catch(e) {
+    el.innerHTML = '<p class="muted-prose" style="margin-top:16px"><em>Audit trail unavailable.</em></p>';
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Data Fetching & Rendering
+   ═══════════════════════════════════════════════════════════════════════ */
+
+const API = {
+  snapshot:     '/api/v2/snapshot',
+  report:       '/api/v2/report',
+  costSeries:   '/api/v2/cost-series',
+  privileges:   '/api/v2/privileges',
+  policies:     '/api/v2/policies',
+  taskBacklog:  '/api/v2/task-backlog',
+};
+
+/* ── Actions API Helper ──────────────────────────────────────────── */
+const Actions = {
+  catalog: null,
+  async loadCatalog() {
+    try { const r = await fetch('/api/v2/actions'); if (r.ok) this.catalog = await r.json(); } catch(e) {}
+    return this.catalog;
+  },
+  async execute(actionId, params = {}, { dryRun = false, confirmToken = '' } = {}) {
+    const r = await fetch('/api/v2/actions/' + actionId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ params, dry_run: dryRun, confirm_token: confirmToken }),
+    });
+    return r.json();
+  }
+};
+
+let state = {
+  snapshot: null,
+  report: null,
+  costSeries: null,
+  privileges: null,
+  policies: null,
+  taskBacklog: null,
+  lastRefresh: null,
+  error: null,
+};
+
+let refreshTimer = null;
+const REFRESH_INTERVAL = 30000;
+
+/* ── Fetch all data ───────────────────────────────────────────────── */
+async function fetchAll() {
+  const results = await Promise.allSettled([
+    fetch(API.snapshot).then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r.json();
+    }),
+    fetch(API.report).then(r => r.ok ? r.json() : null).catch(() => null),
+    fetch(API.costSeries).then(r => r.ok ? r.json() : null).catch(() => null),
+    fetch(API.privileges).then(r => r.ok ? r.json() : null).catch(() => null),
+    fetch(API.policies).then(r => r.ok ? r.json() : null).catch(() => null),
+    fetch(API.taskBacklog).then(r => r.ok ? r.json() : null).catch(() => null),
+  ]);
+
+  // The snapshot is required; others are optional enrichments
+  if (results[0].status === 'rejected') {
+    throw results[0].reason;
+  }
+
+  state.snapshot = results[0].value;
+  state.report = results[1].status === 'fulfilled' ? results[1].value : null;
+  state.costSeries = results[2].status === 'fulfilled' ? results[2].value : null;
+  state.privileges = results[3].status === 'fulfilled' ? results[3].value : null;
+  state.policies = results[4].status === 'fulfilled' ? results[4].value : null;
+  state.taskBacklog = results[5].status === 'fulfilled' ? results[5].value : null;
+  state.lastRefresh = new Date();
+  state.error = null;
+}
+
+/* ── Render ────────────────────────────────────────────────────────── */
+function render() {
+  const snap = state.snapshot;
+  if (!snap) return;
+
+  const loadingEl = document.getElementById('loading-state');
+  const errorEl = document.getElementById('error-state');
+  const mainEl = document.getElementById('main-content');
+
+  loadingEl.style.display = 'none';
+  errorEl.style.display = 'none';
+  mainEl.style.display = 'block';
+
+  // Masthead
+  document.getElementById('meta-timestamp').textContent = fmtTimestamp(snap.timestamp);
+  const branchEl = document.getElementById('meta-branch');
+  if (snap.git?.current_branch) {
+    branchEl.textContent = snap.git.current_branch;
+    branchEl.className = 'branch';
+  }
+
+  // Pulse the refresh indicator
+  const dot = document.getElementById('refresh-dot');
+  dot.classList.remove('active');
+  void dot.offsetWidth; // trigger reflow
+  dot.classList.add('active');
+
+  // I. Executive Summary
+  document.getElementById('executive-summary-text').innerHTML =
+    generateExecutiveSummary(snap);
+
+  // II. Critical Alerts
+  const alerts = snap.alerts || [];
+  const alertSection = document.getElementById('sec-alerts');
+  const alertContent = document.getElementById('alerts-content');
+  if (alerts.length > 0) {
+    alertSection.style.display = 'block';
+    alertContent.innerHTML = generateAlertBlocks(alerts);
+  } else {
+    alertSection.style.display = 'none';
+  }
+
+  // III. Fleet Status
+  document.getElementById('fleet-content').innerHTML =
+    generateFleetStatus(snap);
+
+  // IV. Lane Dispatches
+  document.getElementById('lanes-content').innerHTML =
+    generateLaneDispatches(snap.lanes || []);
+
+  // V. Performance Digest
+  document.getElementById('performance-content').innerHTML =
+    generatePerformanceDigest(snap, state.costSeries);
+
+  // VI. Git Activity
+  document.getElementById('git-content').innerHTML =
+    generateGitActivity(snap.git);
+
+  // VII. Policy & Governance
+  document.getElementById('governance-content').innerHTML =
+    generateGovernance(state.report, state.policies, state.privileges);
+
+  // VIII. Connectivity Report
+  document.getElementById('connectivity-content').innerHTML =
+    generateConnectivity(snap.connectivity);
+
+  // IX. Operator Actions
+  renderOperatorActions();
+  renderAuditTrail();
+
+  // Footer timestamp
+  const colophon = document.getElementById('footer-colophon');
+  colophon.textContent =
+    'MERIDIAN Swarm Intelligence Briefing \u2014 Last updated ' +
+    (state.lastRefresh ? state.lastRefresh.toLocaleTimeString() : 'never');
+}
+
+function showError(err) {
+  const loadingEl = document.getElementById('loading-state');
+  const errorEl = document.getElementById('error-state');
+  const mainEl = document.getElementById('main-content');
+
+  loadingEl.style.display = 'none';
+  errorEl.style.display = 'block';
+
+  document.getElementById('error-detail').textContent =
+    err?.message || 'Unable to reach the swarm API. Retrying...';
+
+  // Keep main visible if we had previous data
+  if (state.snapshot) {
+    mainEl.style.display = 'block';
+  }
+}
+
+/* ── Refresh Cycle ────────────────────────────────────────────────── */
+async function refresh() {
+  try {
+    await fetchAll();
+    render();
+  } catch(err) {
+    state.error = err;
+    showError(err);
+  }
+}
+
+function startAutoRefresh() {
+  stopAutoRefresh();
+  refreshTimer = setInterval(refresh, REFRESH_INTERVAL);
+}
+
+function stopAutoRefresh() {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+/* ── Event Bindings ───────────────────────────────────────────────── */
+document.getElementById('btn-refresh').addEventListener('click', () => {
+  refresh();
+});
+
+document.getElementById('auto-refresh-toggle').addEventListener('change', (e) => {
+  if (e.target.checked) {
+    startAutoRefresh();
+  } else {
+    stopAutoRefresh();
+  }
+});
+
+// Expose action functions to global scope for onclick handlers
+window.doAction = doAction;
+window.confirmModalAction = confirmModalAction;
+window.closeConfirmModal = closeConfirmModal;
+
+/* ── Initialize ───────────────────────────────────────────────────── */
+Actions.loadCatalog().then(() => {
+  return refresh();
+}).then(() => {
+  startAutoRefresh();
+});
+
+})();
+</script>
+</body>
+</html>

--- a/src/orxaq_autonomy/dashboard_v2_prism.html
+++ b/src/orxaq_autonomy/dashboard_v2_prism.html
@@ -1,0 +1,1865 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>PRISM — Spatial Overview</title>
+<style>
+/* ═══════════════════════════════════════════════════════════════════
+   PRISM — Bento Glassmorphism Spatial Overview
+   Zero dependencies. Pure CSS Grid + vanilla JS.
+   ═══════════════════════════════════════════════════════════════════ */
+
+*{margin:0;padding:0;box-sizing:border-box}
+
+@font-face{font-family:'Inter';font-display:swap;src:local('Inter'),local('SF Pro Display'),local('Segoe UI'),local('Helvetica Neue')}
+
+:root{
+  --bg-start:#0a0e17;
+  --bg-end:#111827;
+  --glass:rgba(20,25,35,0.6);
+  --glass-hover:rgba(25,32,48,0.7);
+  --glass-border:rgba(255,255,255,0.08);
+  --glass-border-hover:rgba(255,255,255,0.14);
+  --glass-blur:20px;
+  --radius:16px;
+  --shadow:0 8px 32px rgba(0,0,0,0.2);
+  --shadow-hover:0 16px 48px rgba(0,0,0,0.3);
+  --text:#e2e8f0;
+  --text-secondary:#94a3b8;
+  --muted:#64748b;
+  --accent:#3b82f6;
+  --success:#10b981;
+  --warning:#f59e0b;
+  --critical:#ef4444;
+  --codex-tint:rgba(56,189,248,0.08);
+  --gemini-tint:rgba(251,146,60,0.08);
+  --claude-tint:rgba(168,85,247,0.08);
+  --codex:#38bdf8;
+  --gemini:#fb923c;
+  --claude:#a855f7;
+}
+
+html,body{
+  height:100%;
+  background:linear-gradient(135deg,var(--bg-start) 0%,var(--bg-end) 100%);
+  font-family:'Inter','SF Pro Display','Segoe UI','Helvetica Neue',system-ui,-apple-system,sans-serif;
+  color:var(--text);
+  overflow-x:hidden;
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
+}
+
+/* ── Background noise texture ── */
+body::before{
+  content:'';
+  position:fixed;
+  top:0;left:0;right:0;bottom:0;
+  background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+  background-repeat:repeat;
+  pointer-events:none;
+  z-index:0;
+}
+
+/* ── Ambient glow ── */
+body::after{
+  content:'';
+  position:fixed;
+  top:-50%;left:-50%;
+  width:200%;height:200%;
+  background:radial-gradient(ellipse at 30% 20%,rgba(59,130,246,0.04) 0%,transparent 50%),
+             radial-gradient(ellipse at 70% 80%,rgba(168,85,247,0.03) 0%,transparent 50%);
+  pointer-events:none;
+  z-index:0;
+}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar{width:4px;height:4px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:rgba(100,116,139,0.3);border-radius:2px}
+::-webkit-scrollbar-thumb:hover{background:rgba(100,116,139,0.5)}
+
+/* ── Top Bar ── */
+.top-bar{
+  position:sticky;top:0;z-index:50;
+  display:flex;align-items:center;justify-content:space-between;
+  padding:12px 24px;
+  background:rgba(10,14,23,0.8);
+  backdrop-filter:blur(12px);
+  -webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid rgba(255,255,255,0.04);
+}
+.top-bar-left{display:flex;align-items:center;gap:12px}
+.logo{font-size:13px;font-weight:700;letter-spacing:0.1em;color:var(--accent)}
+.logo span{color:var(--muted);font-weight:400;margin-left:6px;font-size:11px;letter-spacing:0.02em}
+.top-bar-right{display:flex;align-items:center;gap:16px}
+.clock{font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;letter-spacing:0.04em}
+.refresh-indicator{width:6px;height:6px;border-radius:50%;background:var(--accent);opacity:0;transition:opacity 0.3s}
+.refresh-indicator.active{opacity:1}
+
+/* ── Bento Grid ── */
+.bento-grid{
+  position:relative;z-index:1;
+  display:grid;
+  grid-template-columns:repeat(6,1fr);
+  grid-auto-rows:minmax(160px,auto);
+  gap:16px;
+  padding:20px 24px 40px;
+  max-width:1600px;
+  margin:0 auto;
+}
+
+/* ── Glass Tile ── */
+.tile{
+  background:var(--glass);
+  backdrop-filter:blur(var(--glass-blur));
+  -webkit-backdrop-filter:blur(var(--glass-blur));
+  border:1px solid var(--glass-border);
+  border-radius:var(--radius);
+  box-shadow:var(--shadow);
+  padding:20px;
+  cursor:pointer;
+  transition:transform 0.3s ease,box-shadow 0.3s ease,border-color 0.3s ease,background 0.3s ease;
+  position:relative;
+  overflow:hidden;
+  display:flex;
+  flex-direction:column;
+}
+.tile:hover{
+  transform:translateY(-2px);
+  box-shadow:var(--shadow-hover);
+  border-color:var(--glass-border-hover);
+  background:var(--glass-hover);
+}
+.tile::before{
+  content:'';
+  position:absolute;
+  top:0;left:0;right:0;
+  height:1px;
+  background:linear-gradient(90deg,transparent,rgba(255,255,255,0.06),transparent);
+}
+.tile-header{
+  display:flex;align-items:center;justify-content:space-between;
+  margin-bottom:12px;
+}
+.tile-label{
+  font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.1em;color:var(--muted);
+}
+.tile-icon{font-size:12px;color:var(--muted)}
+.tile-body{flex:1;display:flex;flex-direction:column;justify-content:center}
+.tile-footer{margin-top:auto;padding-top:8px}
+
+/* ── Grid placements ── */
+.tile-health       {grid-column:span 1;grid-row:span 1}
+.tile-fleet        {grid-column:span 2;grid-row:span 1}
+.tile-cost         {grid-column:span 1;grid-row:span 1}
+.tile-alerts       {grid-column:span 1;grid-row:span 2}
+.tile-timeline     {grid-column:span 2;grid-row:span 1}
+.tile-git          {grid-column:span 1;grid-row:span 1}
+.tile-quality      {grid-column:span 1;grid-row:span 1}
+.tile-connectivity {grid-column:span 1;grid-row:span 1}
+.tile-active-lanes {grid-column:span 2;grid-row:span 1}
+.tile-tokens       {grid-column:span 1;grid-row:span 1}
+.tile-actions      {grid-column:span 2;grid-row:span 1}
+
+/* ── Health Orb ── */
+.health-orb-wrap{
+  display:flex;align-items:center;justify-content:center;flex:1;
+}
+.health-orb{
+  width:90px;height:90px;border-radius:50%;
+  display:flex;align-items:center;justify-content:center;flex-direction:column;
+  transition:all 0.6s ease;position:relative;
+}
+.health-orb.green{
+  background:radial-gradient(circle,rgba(16,185,129,0.15) 0%,rgba(16,185,129,0.03) 70%);
+  border:2px solid rgba(16,185,129,0.35);
+  box-shadow:0 0 40px rgba(16,185,129,0.1),inset 0 0 20px rgba(16,185,129,0.05);
+}
+.health-orb.amber{
+  background:radial-gradient(circle,rgba(245,158,11,0.15) 0%,rgba(245,158,11,0.03) 70%);
+  border:2px solid rgba(245,158,11,0.35);
+  box-shadow:0 0 40px rgba(245,158,11,0.1),inset 0 0 20px rgba(245,158,11,0.05);
+}
+.health-orb.red{
+  background:radial-gradient(circle,rgba(239,68,68,0.15) 0%,rgba(239,68,68,0.03) 70%);
+  border:2px solid rgba(239,68,68,0.35);
+  box-shadow:0 0 40px rgba(239,68,68,0.1),inset 0 0 20px rgba(239,68,68,0.05);
+}
+.health-orb.pulse{animation:orbPulse 2s ease-in-out infinite}
+@keyframes orbPulse{
+  0%,100%{transform:scale(1);filter:brightness(1)}
+  50%{transform:scale(1.05);filter:brightness(1.15)}
+}
+.health-orb .orb-count{font-size:28px;font-weight:700;line-height:1}
+.health-orb .orb-sub{font-size:9px;font-weight:500;opacity:0.7;margin-top:2px;text-transform:uppercase;letter-spacing:0.06em}
+.health-orb.green .orb-count{color:var(--success)}
+.health-orb.amber .orb-count{color:var(--warning)}
+.health-orb.red .orb-count{color:var(--critical)}
+.health-orb.green .orb-sub{color:var(--success)}
+.health-orb.amber .orb-sub{color:var(--warning)}
+.health-orb.red .orb-sub{color:var(--critical)}
+
+/* ── Fleet stacked bars ── */
+.fleet-row{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.fleet-owner{font-size:11px;font-weight:600;width:56px;text-align:right;flex-shrink:0}
+.fleet-bar-wrap{flex:1;height:20px;border-radius:4px;background:rgba(255,255,255,0.03);overflow:hidden;display:flex;position:relative}
+.fleet-bar-seg{height:100%;transition:width 0.6s ease;position:relative;min-width:1px}
+.fleet-counts{font-size:9px;color:var(--muted);width:48px;text-align:right;flex-shrink:0;font-variant-numeric:tabular-nums}
+
+/* ── Cost ── */
+.cost-big{font-size:32px;font-weight:700;color:var(--text);line-height:1;margin-bottom:8px}
+.cost-big .cost-symbol{font-size:20px;font-weight:400;color:var(--muted)}
+.budget-arc-wrap{position:relative;width:100%;height:36px;margin-bottom:8px}
+.budget-arc-track{width:100%;height:6px;border-radius:3px;background:rgba(255,255,255,0.04);overflow:hidden;position:relative}
+.budget-arc-fill{height:100%;border-radius:3px;transition:width 0.8s ease}
+.budget-label{display:flex;justify-content:space-between;font-size:9px;color:var(--muted);margin-top:4px}
+.sparkline-wrap{height:28px;display:flex;align-items:flex-end;gap:1px;margin-top:4px}
+.sparkline-bar{flex:1;border-radius:1px 1px 0 0;background:var(--accent);opacity:0.5;transition:height 0.4s ease,opacity 0.2s;min-width:2px}
+.sparkline-bar:hover{opacity:1}
+
+/* ── Alert Stack ── */
+.alert-list{flex:1;overflow-y:auto;display:flex;flex-direction:column;gap:6px}
+.alert-card{
+  padding:10px 12px;border-radius:10px;
+  background:rgba(255,255,255,0.02);
+  border-left:3px solid;
+  font-size:11px;line-height:1.4;
+  transition:background 0.2s;
+}
+.alert-card:hover{background:rgba(255,255,255,0.04)}
+.alert-card.high{border-color:var(--critical);color:rgba(239,68,68,0.9)}
+.alert-card.medium{border-color:var(--warning);color:rgba(245,158,11,0.9)}
+.alert-card.low{border-color:var(--accent);color:rgba(59,130,246,0.9)}
+.alert-type{font-size:8px;font-weight:700;text-transform:uppercase;letter-spacing:0.08em;opacity:0.7;margin-bottom:3px}
+.alert-lane{font-size:9px;color:var(--muted);margin-top:4px}
+.alert-empty{display:flex;align-items:center;justify-content:center;flex:1;font-size:12px;color:var(--muted);opacity:0.5}
+
+/* ── Timeline ── */
+.timeline-scroll{display:flex;align-items:center;gap:0;overflow-x:auto;flex:1;padding:12px 0;position:relative}
+.timeline-line{position:absolute;top:50%;left:0;right:0;height:1px;background:rgba(255,255,255,0.06);transform:translateY(-50%)}
+.tl-event{
+  display:flex;flex-direction:column;align-items:center;gap:4px;
+  min-width:40px;position:relative;z-index:1;
+  cursor:default;
+}
+.tl-dot{
+  width:10px;height:10px;border-radius:50%;
+  border:2px solid;transition:transform 0.2s;
+  flex-shrink:0;
+}
+.tl-event:hover .tl-dot{transform:scale(1.4)}
+.tl-time{font-size:7px;color:var(--muted);white-space:nowrap;font-variant-numeric:tabular-nums}
+.tl-label{font-size:7px;color:var(--text-secondary);max-width:60px;text-align:center;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+/* ── Git Pulse ── */
+.git-stat{display:flex;gap:12px;margin-bottom:10px}
+.git-stat-item{text-align:center}
+.git-stat-val{font-size:20px;font-weight:700;color:var(--text)}
+.git-stat-label{font-size:8px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em}
+.git-commit-latest{
+  font-size:10px;color:var(--text-secondary);
+  padding:8px 10px;border-radius:8px;
+  background:rgba(255,255,255,0.02);
+  line-height:1.4;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+}
+.git-commit-hash{color:var(--accent);font-weight:600;margin-right:4px}
+.git-author-dots{display:flex;gap:3px;margin-top:6px}
+.git-author-dot{width:8px;height:8px;border-radius:50%;transition:transform 0.2s}
+.git-author-dot:hover{transform:scale(1.5)}
+
+/* ── Response Quality ── */
+.quality-big{font-size:48px;font-weight:700;line-height:1;margin-bottom:4px;display:flex;align-items:baseline;gap:4px}
+.quality-pct{font-size:18px;font-weight:400;color:var(--muted)}
+.quality-trend{font-size:14px;margin-left:4px}
+.quality-trend.up{color:var(--success)}
+.quality-trend.down{color:var(--critical)}
+.quality-trend.flat{color:var(--muted)}
+.quality-label{font-size:10px;color:var(--muted)}
+
+/* ── Connectivity ── */
+.conn-list{display:flex;flex-direction:column;gap:8px}
+.conn-item{display:flex;align-items:center;gap:8px;font-size:11px}
+.conn-dot{width:7px;height:7px;border-radius:50%;flex-shrink:0;transition:box-shadow 0.3s}
+.conn-dot.ok{background:var(--success);box-shadow:0 0 8px rgba(16,185,129,0.3)}
+.conn-dot.fail{background:var(--critical);box-shadow:0 0 8px rgba(239,68,68,0.3)}
+.conn-name{color:var(--text-secondary);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.conn-latency{font-size:9px;color:var(--muted);font-variant-numeric:tabular-nums}
+
+/* ── Active Lanes ── */
+.active-lanes-grid{display:flex;gap:10px;flex:1;overflow-x:auto}
+.active-lane-card{
+  min-width:180px;max-width:220px;flex:1;
+  padding:12px;border-radius:12px;
+  background:rgba(255,255,255,0.02);
+  border:1px solid rgba(255,255,255,0.04);
+  display:flex;flex-direction:column;gap:6px;
+  transition:border-color 0.2s;
+}
+.active-lane-card:hover{border-color:rgba(255,255,255,0.1)}
+.al-header{display:flex;align-items:center;gap:6px}
+.al-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.al-name{font-size:11px;font-weight:600;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+.al-progress-wrap{height:4px;border-radius:2px;background:rgba(255,255,255,0.04);overflow:hidden}
+.al-progress{height:100%;border-radius:2px;transition:width 0.6s ease}
+.al-meta{display:flex;justify-content:space-between;font-size:9px;color:var(--muted)}
+.al-empty{display:flex;align-items:center;justify-content:center;flex:1;font-size:12px;color:var(--muted);opacity:0.5}
+
+/* ── Token Counter ── */
+.token-big{font-size:28px;font-weight:700;color:var(--text);line-height:1;margin-bottom:4px;font-variant-numeric:tabular-nums}
+.token-rate{font-size:11px;color:var(--text-secondary);display:flex;align-items:center;gap:4px}
+.token-rate-arrow{font-size:12px}
+
+/* ── Action Chips ── */
+.action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  background: rgba(59,130,246,0.1);
+  border: 1px solid rgba(59,130,246,0.2);
+  border-radius: 6px;
+  color: var(--accent, #3b82f6);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+.action-chip:hover {
+  background: rgba(59,130,246,0.2);
+  border-color: rgba(59,130,246,0.3);
+  transform: translateY(-1px);
+}
+.action-chip.danger {
+  background: rgba(239,68,68,0.1);
+  border-color: rgba(239,68,68,0.2);
+  color: var(--critical, #ef4444);
+}
+.action-chip.danger:hover {
+  background: rgba(239,68,68,0.2);
+}
+.action-chip.success {
+  background: rgba(34,197,94,0.1);
+  border-color: rgba(34,197,94,0.2);
+  color: var(--success, #22c55e);
+}
+.audit-entry {
+  font-size: 10px;
+  color: var(--muted, #888);
+  padding: 3px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+
+/* ── Confirmation Overlay ── */
+#confirmOverlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 2000;
+  display: flex; align-items: center; justify-content: center;
+  backdrop-filter: blur(4px);
+}
+.confirm-glass {
+  background: rgba(30,30,50,0.9);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 450px;
+  width: 90%;
+  backdrop-filter: blur(20px);
+}
+.confirm-header {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: var(--text, #fff);
+}
+.confirm-actions { display: flex; gap: 8px; margin-top: 16px; }
+
+/* ── Skeleton Loading ── */
+.skeleton{position:relative;overflow:hidden}
+.skeleton::after{
+  content:'';position:absolute;top:0;left:-100%;width:100%;height:100%;
+  background:linear-gradient(90deg,transparent,rgba(255,255,255,0.03),transparent);
+  animation:shimmer 1.5s infinite;
+}
+@keyframes shimmer{to{left:100%}}
+.skel-line{height:12px;border-radius:4px;background:rgba(255,255,255,0.04);margin-bottom:8px}
+.skel-circle{width:80px;height:80px;border-radius:50%;background:rgba(255,255,255,0.03);margin:auto}
+.skel-bar{height:20px;border-radius:4px;background:rgba(255,255,255,0.03);margin-bottom:8px}
+
+/* ── Expanded Overlay ── */
+.overlay{
+  position:fixed;top:0;left:0;right:0;bottom:0;
+  z-index:200;
+  display:flex;align-items:center;justify-content:center;
+  background:rgba(10,14,23,0);
+  backdrop-filter:blur(0px);
+  -webkit-backdrop-filter:blur(0px);
+  pointer-events:none;
+  opacity:0;
+  transition:background 0.4s ease,backdrop-filter 0.4s ease,-webkit-backdrop-filter 0.4s ease,opacity 0.4s ease;
+}
+.overlay.open{
+  background:rgba(10,14,23,0.6);
+  backdrop-filter:blur(12px);
+  -webkit-backdrop-filter:blur(12px);
+  pointer-events:auto;
+  opacity:1;
+}
+.overlay-panel{
+  background:rgba(20,25,35,0.85);
+  backdrop-filter:blur(30px);
+  -webkit-backdrop-filter:blur(30px);
+  border:1px solid rgba(255,255,255,0.1);
+  border-radius:20px;
+  box-shadow:0 24px 80px rgba(0,0,0,0.4);
+  width:90%;max-width:700px;max-height:80vh;
+  overflow-y:auto;
+  padding:28px;
+  transform:scale(0.95) translateY(10px);
+  transition:transform 0.4s ease;
+}
+.overlay.open .overlay-panel{transform:scale(1) translateY(0)}
+.overlay-close{
+  position:absolute;top:16px;right:20px;
+  background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.08);
+  color:var(--muted);font-size:14px;
+  width:32px;height:32px;border-radius:8px;
+  cursor:pointer;display:flex;align-items:center;justify-content:center;
+  transition:background 0.2s,color 0.2s;
+}
+.overlay-close:hover{background:rgba(255,255,255,0.1);color:var(--text)}
+.overlay-title{font-size:16px;font-weight:700;margin-bottom:20px;color:var(--text);padding-right:40px}
+.overlay-section{font-size:9px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:0.12em;margin:20px 0 10px;padding-top:16px;border-top:1px solid rgba(255,255,255,0.04)}
+.overlay-section:first-of-type{margin-top:0;padding-top:0;border-top:none}
+
+/* Detail grids */
+.detail-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:10px;margin-bottom:12px}
+.detail-card{background:rgba(255,255,255,0.03);border-radius:10px;padding:12px;text-align:center}
+.detail-card-label{font-size:8px;color:var(--muted);text-transform:uppercase;letter-spacing:0.08em;margin-bottom:4px}
+.detail-card-val{font-size:18px;font-weight:700}
+.detail-list{display:flex;flex-direction:column;gap:4px}
+.detail-list-item{
+  display:flex;align-items:center;gap:8px;
+  padding:8px 10px;border-radius:8px;
+  background:rgba(255,255,255,0.02);
+  font-size:11px;
+}
+.detail-list-item:hover{background:rgba(255,255,255,0.04)}
+.health-check{display:flex;align-items:center;gap:8px;padding:6px 0;font-size:11px;border-bottom:1px solid rgba(255,255,255,0.03)}
+.health-check:last-child{border-bottom:none}
+.check-icon{width:18px;height:18px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;flex-shrink:0}
+.check-icon.pass{background:rgba(16,185,129,0.12);color:var(--success)}
+.check-icon.fail{background:rgba(239,68,68,0.12);color:var(--critical)}
+.check-name{flex:1;color:var(--text-secondary)}
+.check-value{color:var(--muted);font-size:10px;font-variant-numeric:tabular-nums}
+
+/* Cost chart */
+.cost-chart{display:flex;align-items:flex-end;gap:2px;height:80px;margin-top:8px}
+.cost-chart-bar{flex:1;border-radius:2px 2px 0 0;background:var(--accent);opacity:0.6;transition:opacity 0.2s;min-width:4px;position:relative}
+.cost-chart-bar:hover{opacity:1}
+.cost-chart-bar .bar-tooltip{
+  display:none;position:absolute;bottom:calc(100% + 4px);left:50%;transform:translateX(-50%);
+  background:rgba(10,14,23,0.95);border:1px solid rgba(255,255,255,0.1);border-radius:6px;
+  padding:4px 8px;font-size:9px;color:var(--text);white-space:nowrap;z-index:10;
+}
+.cost-chart-bar:hover .bar-tooltip{display:block}
+
+/* Fleet detail bar */
+.fleet-detail-bar{display:flex;gap:2px;height:24px;border-radius:4px;overflow:hidden;margin:4px 0}
+.fleet-detail-seg{height:100%;transition:width 0.4s;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:600;color:rgba(255,255,255,0.7);overflow:hidden}
+
+/* Timeline detail */
+.tl-detail-item{display:flex;align-items:flex-start;gap:10px;padding:8px 0;border-bottom:1px solid rgba(255,255,255,0.03)}
+.tl-detail-dot{width:8px;height:8px;border-radius:50%;margin-top:4px;flex-shrink:0}
+.tl-detail-content{flex:1;font-size:11px}
+.tl-detail-time{font-size:9px;color:var(--muted);font-variant-numeric:tabular-nums}
+.tl-detail-lane{font-size:9px;color:var(--muted)}
+.tl-detail-body{color:var(--text-secondary);margin-top:2px}
+
+/* ── Responsive ── */
+@media(max-width:1200px){
+  .bento-grid{grid-template-columns:repeat(4,1fr)}
+  .tile-fleet,.tile-timeline,.tile-active-lanes,.tile-actions{grid-column:span 2}
+}
+@media(max-width:800px){
+  .bento-grid{grid-template-columns:repeat(2,1fr);gap:12px;padding:12px 16px 32px}
+  .tile-fleet,.tile-timeline,.tile-active-lanes,.tile-actions{grid-column:span 2}
+  .tile-alerts{grid-row:span 1}
+  .tile{padding:16px}
+}
+@media(max-width:480px){
+  .bento-grid{grid-template-columns:1fr;gap:10px;padding:10px 12px 28px}
+  .tile-fleet,.tile-timeline,.tile-active-lanes,.tile-actions{grid-column:span 1}
+  .top-bar{padding:10px 16px}
+}
+
+/* ── Number count-up ── */
+.anim-val{transition:none}
+
+/* ── Tooltip ── */
+.tt{
+  position:fixed;z-index:300;
+  background:rgba(10,14,23,0.95);
+  border:1px solid rgba(255,255,255,0.1);
+  border-radius:8px;
+  padding:8px 12px;font-size:10px;color:var(--text);
+  pointer-events:none;
+  box-shadow:0 8px 24px rgba(0,0,0,0.3);
+  max-width:260px;
+  opacity:0;transition:opacity 0.15s;
+}
+.tt.visible{opacity:1}
+</style>
+</head>
+<body>
+
+<!-- Top Bar -->
+<div class="top-bar">
+  <div class="top-bar-left">
+    <div class="logo">PRISM<span>Spatial Overview</span></div>
+  </div>
+  <div class="top-bar-right">
+    <div class="refresh-indicator" id="refreshDot"></div>
+    <div class="clock" id="clock"></div>
+  </div>
+</div>
+
+<!-- Bento Grid -->
+<div class="bento-grid" id="bentoGrid">
+
+  <!-- 1. Health Orb (1x1) -->
+  <div class="tile tile-health" data-tile="health" id="tileHealth">
+    <div class="tile-header">
+      <span class="tile-label">System Health</span>
+    </div>
+    <div class="tile-body">
+      <div class="health-orb-wrap">
+        <div class="health-orb green" id="healthOrb">
+          <span class="orb-count" id="healthCount">0</span>
+          <span class="orb-sub" id="healthSub">alerts</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2. Fleet Overview (2x1) -->
+  <div class="tile tile-fleet" data-tile="fleet" id="tileFleet">
+    <div class="tile-header">
+      <span class="tile-label">Fleet Overview</span>
+      <span class="tile-icon" id="fleetTotal"></span>
+    </div>
+    <div class="tile-body" id="fleetBody">
+      <div class="skeleton"><div class="skel-bar"></div><div class="skel-bar"></div><div class="skel-bar"></div></div>
+    </div>
+  </div>
+
+  <!-- 3. Cost Tracker (1x1) -->
+  <div class="tile tile-cost" data-tile="cost" id="tileCost">
+    <div class="tile-header">
+      <span class="tile-label">Cost Tracker</span>
+    </div>
+    <div class="tile-body">
+      <div class="cost-big"><span class="cost-symbol">$</span><span id="costValue">0.00</span></div>
+      <div class="budget-arc-wrap">
+        <div class="budget-arc-track"><div class="budget-arc-fill" id="budgetFill" style="width:0%;background:var(--success)"></div></div>
+        <div class="budget-label"><span id="budgetSpent">$0</span><span id="budgetCap">$100</span></div>
+      </div>
+      <div class="sparkline-wrap" id="costSparkline"></div>
+    </div>
+  </div>
+
+  <!-- 4. Alert Stack (1x2) -->
+  <div class="tile tile-alerts" data-tile="alerts" id="tileAlerts">
+    <div class="tile-header">
+      <span class="tile-label">Alerts</span>
+      <span class="tile-icon" id="alertCount" style="font-weight:700"></span>
+    </div>
+    <div class="alert-list" id="alertList">
+      <div class="alert-empty">No active alerts</div>
+    </div>
+  </div>
+
+  <!-- 5. Timeline (2x1) -->
+  <div class="tile tile-timeline" data-tile="timeline" id="tileTimeline">
+    <div class="tile-header">
+      <span class="tile-label">Timeline</span>
+      <span class="tile-icon" id="timelineCount"></span>
+    </div>
+    <div class="tile-body" style="position:relative;overflow:hidden">
+      <div class="timeline-line"></div>
+      <div class="timeline-scroll" id="timelineScroll"></div>
+    </div>
+  </div>
+
+  <!-- 6. Git Pulse (1x1) -->
+  <div class="tile tile-git" data-tile="git" id="tileGit">
+    <div class="tile-header">
+      <span class="tile-label">Git Pulse</span>
+    </div>
+    <div class="tile-body">
+      <div class="git-stat">
+        <div class="git-stat-item"><div class="git-stat-val" id="gitBranches">0</div><div class="git-stat-label">Branches</div></div>
+        <div class="git-stat-item"><div class="git-stat-val" id="gitCommits">0</div><div class="git-stat-label">Commits</div></div>
+      </div>
+      <div class="git-commit-latest" id="gitLatest">
+        <span class="skeleton"><span class="skel-line" style="width:80%"></span></span>
+      </div>
+      <div class="git-author-dots" id="gitAuthors"></div>
+    </div>
+  </div>
+
+  <!-- 7. Response Quality (1x1) -->
+  <div class="tile tile-quality" data-tile="quality" id="tileQuality">
+    <div class="tile-header">
+      <span class="tile-label">Response Quality</span>
+    </div>
+    <div class="tile-body">
+      <div class="quality-big">
+        <span id="qualityValue" style="color:var(--muted)">--</span>
+        <span class="quality-pct">%</span>
+        <span class="quality-trend flat" id="qualityTrend"></span>
+      </div>
+      <div class="quality-label">First-time pass rate</div>
+    </div>
+  </div>
+
+  <!-- 8. Connectivity (1x1) -->
+  <div class="tile tile-connectivity" data-tile="connectivity" id="tileConnectivity">
+    <div class="tile-header">
+      <span class="tile-label">Connectivity</span>
+    </div>
+    <div class="tile-body">
+      <div class="conn-list" id="connList">
+        <div class="skeleton"><div class="skel-line" style="width:60%"></div><div class="skel-line" style="width:80%"></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 9. Active Lanes (2x1) -->
+  <div class="tile tile-active-lanes" data-tile="activeLanes" id="tileActiveLanes">
+    <div class="tile-header">
+      <span class="tile-label">Active Lanes</span>
+      <span class="tile-icon" id="activeCount"></span>
+    </div>
+    <div class="tile-body">
+      <div class="active-lanes-grid" id="activeLanesGrid">
+        <div class="al-empty">No active lanes</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 10. Token Counter (1x1) -->
+  <div class="tile tile-tokens" data-tile="tokens" id="tileTokens">
+    <div class="tile-header">
+      <span class="tile-label">Tokens</span>
+    </div>
+    <div class="tile-body">
+      <div class="token-big" id="tokenValue">0</div>
+      <div class="token-rate">
+        <span class="token-rate-arrow" id="tokenRateArrow"></span>
+        <span id="tokenRate">-- tok/min</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 11. Actions (2x1) -->
+  <div class="tile tile-actions" onclick="openExpanded('actions')" style="grid-column: span 2;">
+    <div class="tile-header">
+      <span class="tile-label">ACTIONS</span>
+      <span class="tile-icon">&#9881;</span>
+    </div>
+    <div class="tile-body" id="actionsBody">
+      <!-- Dynamically populated -->
+    </div>
+  </div>
+
+</div>
+
+<!-- Expanded Overlay -->
+<div class="overlay" id="overlay">
+  <div class="overlay-panel" id="overlayPanel" style="position:relative">
+    <button class="overlay-close" id="overlayClose">&times;</button>
+    <div class="overlay-title" id="overlayTitle"></div>
+    <div id="overlayBody"></div>
+  </div>
+</div>
+
+<!-- Tooltip -->
+<div class="tt" id="tooltip"></div>
+
+<!-- Confirmation Overlay -->
+<div id="confirmOverlay" style="display:none">
+  <div class="confirm-glass">
+    <div class="confirm-header">Confirm Action</div>
+    <div id="confirmContent"></div>
+    <div class="confirm-actions">
+      <button class="action-chip" onclick="confirmPendingAction()">Confirm</button>
+      <button class="action-chip" style="color:var(--muted);border-color:rgba(255,255,255,0.1)" onclick="closeConfirm()">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ═══════════════════════════════════════════════════════════════════
+   PRISM — Dashboard Logic
+   ═══════════════════════════════════════════════════════════════════ */
+
+// ── State ──
+let DATA = null;
+let COST_DATA = null;
+let REPORT_DATA = null;
+let expandedTile = null;
+let firstLoad = true;
+let previousPassRate = null;
+const POLL_MS = 8000;
+const OWNER_COLORS = {codex:'#38bdf8',gemini:'#fb923c',claude:'#a855f7'};
+const STATUS_COLORS = {done:'#10b981',in_progress:'#3b82f6',blocked:'#ef4444',pending:'#f59e0b',idle:'#64748b'};
+const EVT_COLORS = {
+  task_selected:'#3b82f6',task_done:'#10b981',task_blocked:'#ef4444',
+  routing_decision:'#a855f7',agent_error:'#f59e0b',prompt:'#64748b',
+  conversation_start:'#3b82f6',conversation_end:'#10b981',
+};
+
+// ── Utilities ──
+function esc(s){
+  if(s==null) return '';
+  const d=document.createElement('div');
+  d.textContent=String(s);
+  return d.innerHTML;
+}
+function formatTokens(n){
+  if(n>=1e6) return (n/1e6).toFixed(1)+'M';
+  if(n>=1e3) return (n/1e3).toFixed(0)+'K';
+  return String(n);
+}
+function formatCost(n){return n.toFixed(2)}
+function clamp(v,lo,hi){return Math.max(lo,Math.min(hi,v))}
+
+// ── Animate number count-up ──
+function animateValue(el,start,end,duration,formatter){
+  if(!el) return;
+  const startTime=performance.now();
+  const delta=end-start;
+  function tick(now){
+    const elapsed=now-startTime;
+    const progress=clamp(elapsed/duration,0,1);
+    const eased=1-Math.pow(1-progress,3); // ease-out cubic
+    const current=start+delta*eased;
+    el.textContent=formatter?formatter(current):Math.round(current).toString();
+    if(progress<1) requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+}
+
+// ── Actions API ──
+const Actions = {
+  catalog: null,
+  async loadCatalog() {
+    try { const r = await fetch('/api/v2/actions'); if (r.ok) this.catalog = await r.json(); } catch(e) {}
+    return this.catalog;
+  },
+  async execute(actionId, params = {}, { dryRun = false, confirmToken = '' } = {}) {
+    const r = await fetch('/api/v2/actions/' + actionId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ params, dry_run: dryRun, confirm_token: confirmToken }),
+    });
+    return r.json();
+  }
+};
+
+let pendingAction = null;
+
+async function doAction(actionId, params = {}, evt) {
+  if (evt) evt.stopPropagation();
+  const def = Actions.catalog?.find(a => a.action_id === actionId);
+  if (def && def.requires_confirmation) {
+    const preview = await Actions.execute(actionId, params, { dryRun: true });
+    if (!preview.ok && !preview.confirm_token) {
+      showToast('Action failed: ' + preview.message, 'error');
+      return;
+    }
+    pendingAction = { actionId, params, token: preview.confirm_token };
+    document.getElementById('confirmContent').innerHTML =
+      '<p style="font-size:12px;margin:0 0 8px">' + esc(preview.message) + '</p>' +
+      '<pre style="font-size:10px;color:var(--muted);background:rgba(0,0,0,0.3);padding:8px;border-radius:6px;overflow:auto;max-height:150px">' +
+      esc(JSON.stringify(preview.detail, null, 2)) + '</pre>';
+    document.getElementById('confirmOverlay').style.display = 'flex';
+  } else {
+    const result = await Actions.execute(actionId, params);
+    showToast(result.ok ? result.message : ('Failed: ' + result.message), result.ok ? 'success' : 'error');
+    if (result.ok) setTimeout(refreshData, 800);
+  }
+}
+
+async function confirmPendingAction() {
+  if (!pendingAction) return;
+  const result = await Actions.execute(
+    pendingAction.actionId, pendingAction.params,
+    { confirmToken: pendingAction.token });
+  closeConfirm();
+  showToast(result.ok ? result.message : ('Failed: ' + result.message), result.ok ? 'success' : 'error');
+  if (result.ok) setTimeout(refreshData, 800);
+}
+
+function closeConfirm() {
+  document.getElementById('confirmOverlay').style.display = 'none';
+  pendingAction = null;
+}
+
+function showToast(msg, type = 'info') {
+  let toast = document.getElementById('actionToast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'actionToast';
+    toast.style.cssText = 'position:fixed;bottom:24px;right:24px;padding:10px 18px;border-radius:8px;font-size:12px;font-weight:600;z-index:3000;transition:opacity 0.3s;backdrop-filter:blur(12px);';
+    document.body.appendChild(toast);
+  }
+  toast.textContent = msg;
+  toast.style.background = type === 'success' ? 'rgba(34,197,94,0.2)' : type === 'error' ? 'rgba(239,68,68,0.2)' : 'rgba(59,130,246,0.2)';
+  toast.style.border = '1px solid ' + (type === 'success' ? 'rgba(34,197,94,0.3)' : type === 'error' ? 'rgba(239,68,68,0.3)' : 'rgba(59,130,246,0.3)');
+  toast.style.color = type === 'success' ? '#22c55e' : type === 'error' ? '#ef4444' : '#3b82f6';
+  toast.style.opacity = '1';
+  setTimeout(() => { toast.style.opacity = '0'; }, 3000);
+}
+
+// ── Clock ──
+function updateClock(){
+  const el=document.getElementById('clock');
+  if(el) el.textContent=new Date().toISOString().slice(11,19)+'Z';
+}
+setInterval(updateClock,1000);
+updateClock();
+
+// ── Data Fetching ──
+async function fetchJSON(url){
+  try{
+    const r=await fetch(url);
+    if(!r.ok) return null;
+    return await r.json();
+  }catch(e){return null;}
+}
+
+async function refreshData(){
+  const dot=document.getElementById('refreshDot');
+  dot.classList.add('active');
+
+  const [snapshot,costSeries,report]=await Promise.all([
+    fetchJSON('/api/v2/snapshot'),
+    fetchJSON('/api/v2/cost-series'),
+    fetchJSON('/api/v2/report'),
+  ]);
+
+  if(snapshot) DATA=snapshot;
+  if(costSeries) COST_DATA=costSeries;
+  if(report) REPORT_DATA=report;
+
+  if(DATA) render();
+  if(expandedTile) renderExpanded(expandedTile);
+
+  setTimeout(()=>dot.classList.remove('active'),500);
+  firstLoad=false;
+}
+
+// ── Main Render ──
+function render(){
+  if(!DATA) return;
+  renderHealth();
+  renderFleet();
+  renderCost();
+  renderAlerts();
+  renderTimeline();
+  renderGit();
+  renderQuality();
+  renderConnectivity();
+  renderActiveLanes();
+  renderTokens();
+  renderActionsTile();
+}
+
+// ── 1. Health Orb ──
+function renderHealth(){
+  const alerts=DATA.alerts||[];
+  const hasCrit=alerts.some(a=>a.severity==='high');
+  const orb=document.getElementById('healthOrb');
+  const count=document.getElementById('healthCount');
+  const sub=document.getElementById('healthSub');
+
+  if(alerts.length===0){
+    orb.className='health-orb green';
+    count.textContent='\u2713';
+    sub.textContent='healthy';
+  }else if(hasCrit){
+    orb.className='health-orb red pulse';
+    if(firstLoad) animateValue(count,0,alerts.length,600);
+    else count.textContent=alerts.length;
+    sub.textContent=alerts.length===1?'alert':'alerts';
+  }else{
+    orb.className='health-orb amber pulse';
+    if(firstLoad) animateValue(count,0,alerts.length,600);
+    else count.textContent=alerts.length;
+    sub.textContent=alerts.length===1?'alert':'alerts';
+  }
+}
+
+// ── 2. Fleet Overview ──
+function renderFleet(){
+  const lanes=DATA.lanes||[];
+  const grouped={};
+  lanes.forEach(l=>{
+    const o=l.owner||'unknown';
+    if(!grouped[o]) grouped[o]={done:0,in_progress:0,pending:0,blocked:0,idle:0,total:0};
+    const g=grouped[o];
+    g.total++;
+    const st=l.status||'idle';
+    if(g[st]!==undefined) g[st]++;
+  });
+
+  document.getElementById('fleetTotal').textContent=lanes.length+' lanes';
+
+  const body=document.getElementById('fleetBody');
+  let html='';
+  Object.entries(grouped).sort().forEach(([owner,counts])=>{
+    const color=OWNER_COLORS[owner]||'#64748b';
+    const total=counts.total||1;
+    const segments=[
+      {status:'done',count:counts.done},
+      {status:'in_progress',count:counts.in_progress},
+      {status:'pending',count:counts.pending},
+      {status:'blocked',count:counts.blocked},
+      {status:'idle',count:counts.idle},
+    ].filter(s=>s.count>0);
+
+    html+=`<div class="fleet-row">
+      <div class="fleet-owner" style="color:${color}">${esc(owner)}</div>
+      <div class="fleet-bar-wrap">
+        ${segments.map(s=>{
+          const w=(s.count/total*100).toFixed(1);
+          const c=STATUS_COLORS[s.status]||'#64748b';
+          return `<div class="fleet-bar-seg" style="width:${w}%;background:${c}" title="${s.count} ${s.status}"></div>`;
+        }).join('')}
+      </div>
+      <div class="fleet-counts">${counts.done}/${total}</div>
+    </div>`;
+  });
+  body.innerHTML=html;
+}
+
+// ── 3. Cost Tracker ──
+function renderCost(){
+  const s=DATA.summary||{};
+  const cost=s.total_cost_usd||0;
+  const health=DATA.health?.health||{};
+  const cap=health.budget_daily_cap||100;
+  const pct=clamp(cost/cap,0,1);
+
+  const costEl=document.getElementById('costValue');
+  if(firstLoad) animateValue(costEl,0,cost,800,v=>formatCost(v));
+  else costEl.textContent=formatCost(cost);
+
+  const fill=document.getElementById('budgetFill');
+  fill.style.width=(pct*100).toFixed(1)+'%';
+  fill.style.background=pct>0.8?'var(--critical)':pct>0.5?'var(--warning)':'var(--success)';
+
+  document.getElementById('budgetSpent').textContent='$'+formatCost(cost);
+  document.getElementById('budgetCap').textContent='$'+cap;
+
+  // Sparkline from cost series
+  const wrap=document.getElementById('costSparkline');
+  if(COST_DATA&&COST_DATA.hourly_series&&COST_DATA.hourly_series.length>0){
+    const series=COST_DATA.hourly_series;
+    const maxVal=Math.max(...series.map(d=>d.cost||d.value||0),0.01);
+    wrap.innerHTML=series.map(d=>{
+      const v=d.cost||d.value||0;
+      const h=Math.max(2,(v/maxVal)*28);
+      return `<div class="sparkline-bar" style="height:${h}px" title="$${v.toFixed(4)}"></div>`;
+    }).join('');
+  }else{
+    wrap.innerHTML='';
+  }
+}
+
+// ── 4. Alert Stack ──
+function renderAlerts(){
+  const alerts=DATA.alerts||[];
+  document.getElementById('alertCount').textContent=alerts.length||'';
+  document.getElementById('alertCount').style.color=alerts.length>0?'var(--critical)':'var(--muted)';
+
+  const list=document.getElementById('alertList');
+  if(alerts.length===0){
+    list.innerHTML='<div class="alert-empty">No active alerts</div>';
+    return;
+  }
+  list.innerHTML=alerts.map(a=>`
+    <div class="alert-card ${esc(a.severity||'medium')}">
+      <div class="alert-type">${esc(a.type||'')}</div>
+      <div>${esc(a.message||'')}</div>
+      ${a.lane_id?`<div class="alert-lane">${esc(a.lane_id)}</div>`:''}
+    </div>
+  `).join('');
+}
+
+// ── 5. Timeline ──
+function renderTimeline(){
+  const events=(DATA.events||[]).slice(0,20);
+  document.getElementById('timelineCount').textContent=events.length?events.length+' events':'';
+
+  const scroll=document.getElementById('timelineScroll');
+  if(events.length===0){
+    scroll.innerHTML='<div style="text-align:center;font-size:11px;color:var(--muted);width:100%">No events</div>';
+    return;
+  }
+  scroll.innerHTML=events.map(evt=>{
+    const type=evt.type||evt.event_type||'';
+    const color=EVT_COLORS[type]||'#64748b';
+    const ts=evt.timestamp?evt.timestamp.slice(11,19):'';
+    const body=(evt.message||evt.summary||evt.body||type).slice(0,30);
+    return `<div class="tl-event" title="${esc(String(evt.message||evt.summary||evt.body||type).slice(0,100))}">
+      <div class="tl-time">${esc(ts)}</div>
+      <div class="tl-dot" style="border-color:${color};background:${color}30"></div>
+      <div class="tl-label">${esc(body)}</div>
+    </div>`;
+  }).join('');
+}
+
+// ── 6. Git Pulse ──
+function renderGit(){
+  const git=DATA.git||{};
+  const commits=git.recent_commits||[];
+  const branchEl=document.getElementById('gitBranches');
+  const commitEl=document.getElementById('gitCommits');
+
+  if(firstLoad){
+    animateValue(branchEl,0,git.branch_count||0,600);
+    animateValue(commitEl,0,commits.length,600);
+  }else{
+    branchEl.textContent=git.branch_count||0;
+    commitEl.textContent=commits.length;
+  }
+
+  const latest=document.getElementById('gitLatest');
+  if(commits.length>0){
+    const c=commits[0];
+    latest.innerHTML=`<span class="git-commit-hash">${esc((c.short_hash||c.hash||'').slice(0,7))}</span>${esc((c.message||'').slice(0,50))}`;
+  }else{
+    latest.innerHTML='<span style="color:var(--muted)">No recent commits</span>';
+  }
+
+  // Author dots
+  const authorMap={};
+  commits.forEach(c=>{if(c.author) authorMap[c.author]=(authorMap[c.author]||0)+1;});
+  const dots=document.getElementById('gitAuthors');
+  dots.innerHTML=Object.entries(authorMap).map(([a,n])=>{
+    const color=OWNER_COLORS[a]||'#64748b';
+    return `<div class="git-author-dot" style="background:${color};box-shadow:0 0 6px ${color}40" title="${esc(a)} (${n})"></div>`;
+  }).join('');
+}
+
+// ── 7. Response Quality ──
+function renderQuality(){
+  const lanes=DATA.lanes||[];
+  let totalPass=0,totalResp=0;
+  lanes.forEach(l=>{
+    const m=l.metrics||{};
+    const r=m.responses_total||0;
+    const p=m.first_time_pass_rate||0;
+    totalPass+=p*r;
+    totalResp+=r;
+  });
+  const rate=totalResp>0?(totalPass/totalResp):0;
+  const pct=Math.round(rate*100);
+  const valEl=document.getElementById('qualityValue');
+
+  if(firstLoad){
+    animateValue(valEl,0,pct,800);
+  }else{
+    valEl.textContent=pct;
+  }
+
+  // Color
+  if(pct>=60) valEl.style.color='var(--success)';
+  else if(pct>=40) valEl.style.color='var(--warning)';
+  else valEl.style.color='var(--critical)';
+
+  // Trend
+  const trend=document.getElementById('qualityTrend');
+  if(previousPassRate!==null){
+    if(pct>previousPassRate){trend.textContent='\u2191';trend.className='quality-trend up';}
+    else if(pct<previousPassRate){trend.textContent='\u2193';trend.className='quality-trend down';}
+    else{trend.textContent='\u2192';trend.className='quality-trend flat';}
+  }
+  previousPassRate=pct;
+}
+
+// ── 8. Connectivity ──
+function renderConnectivity(){
+  const conn=DATA.connectivity||{};
+  const list=document.getElementById('connList');
+  const endpoints=conn.endpoints||[];
+  if(!Array.isArray(endpoints)||endpoints.length===0){
+    list.innerHTML='<div style="font-size:11px;color:var(--muted);opacity:0.5">No endpoint data</div>';
+    return;
+  }
+  list.innerHTML=endpoints.slice(0,5).map(ep=>{
+    const ok=ep.ok||ep.status==='ok';
+    const lat=ep.latency!=null?(ep.latency+'ms'):'';
+    return `<div class="conn-item">
+      <div class="conn-dot ${ok?'ok':'fail'}"></div>
+      <div class="conn-name">${esc(ep.id||ep.name||'')}</div>
+      <div class="conn-latency">${esc(lat)}</div>
+    </div>`;
+  }).join('');
+}
+
+// ── 9. Active Lanes ──
+function renderActiveLanes(){
+  const lanes=(DATA.lanes||[]).filter(l=>l.status==='in_progress');
+  document.getElementById('activeCount').textContent=lanes.length?lanes.length+' active':'';
+
+  const grid=document.getElementById('activeLanesGrid');
+  if(lanes.length===0){
+    grid.innerHTML='<div class="al-empty">No active lanes</div>';
+    return;
+  }
+  grid.innerHTML=lanes.map(lane=>{
+    const tc=lane.task_counts||{};
+    const total=(tc.done||0)+(tc.in_progress||0)+(tc.pending||0)+(tc.blocked||0);
+    const done=tc.done||0;
+    const pct=total>0?(done/total*100):0;
+    const ownerColor=OWNER_COLORS[lane.owner]||'#64748b';
+    const hb=lane.heartbeat||{};
+    const hbAge=hb.age_sec!=null&&hb.age_sec>=0?hb.age_sec+'s':'--';
+    return `<div class="active-lane-card">
+      <div class="al-header">
+        <div class="al-dot" style="background:${ownerColor};box-shadow:0 0 6px ${ownerColor}40"></div>
+        <div class="al-name">${esc(lane.lane_id)}</div>
+      </div>
+      <div class="al-progress-wrap"><div class="al-progress" style="width:${pct.toFixed(1)}%;background:${ownerColor}"></div></div>
+      <div class="al-meta"><span>${done}/${total} tasks</span><span>${esc(hbAge)} ago</span></div>
+    </div>`;
+  }).join('');
+}
+
+// ── 10. Token Counter ──
+function renderTokens(){
+  const s=DATA.summary||{};
+  const tokens=s.total_tokens||0;
+  const el=document.getElementById('tokenValue');
+
+  if(firstLoad){
+    animateValue(el,0,tokens,1000,v=>formatTokens(Math.round(v)));
+  }else{
+    el.textContent=formatTokens(tokens);
+  }
+
+  // Estimate rate from metrics
+  const metrics=DATA.metrics?.global||{};
+  const rate=metrics.token_rate_per_minute||0;
+  const rateEl=document.getElementById('tokenRate');
+  const arrowEl=document.getElementById('tokenRateArrow');
+  if(rate>0){
+    rateEl.textContent=Math.round(rate)+' tok/min';
+    arrowEl.textContent='\u2191';
+    arrowEl.style.color='var(--success)';
+  }else{
+    rateEl.textContent='-- tok/min';
+    arrowEl.textContent='';
+  }
+}
+
+// ── 11. Actions Tile ──
+function renderActionsTile() {
+  const body = document.getElementById('actionsBody');
+  if (!body) return;
+  let html = '';
+
+  // Contextual: blocked tasks
+  const blockedLanes = (DATA.lanes || []).filter(l => l.status === 'blocked');
+  for (const lane of blockedLanes.slice(0, 3)) {
+    for (const task of (lane.tasks || []).filter(t => t.status === 'blocked').slice(0, 2)) {
+      html += '<div style="margin-bottom:6px">';
+      html += '<span style="font-size:10px;color:var(--muted)">' + esc(task.task_id) + '</span> ';
+      html += '<button class="action-chip" onclick="doAction(\'task.clear-error\',{task_id:\'' + esc(task.task_id) + '\'},event)">Clear & Retry</button>';
+      html += '</div>';
+    }
+  }
+
+  // Quick actions
+  html += '<div style="margin-top:8px;display:flex;flex-wrap:wrap;gap:4px">';
+  html += '<button class="action-chip" onclick="doAction(\'git.heal-locks\',{},event)">Heal Git Locks</button>';
+  html += '<button class="action-chip" onclick="doAction(\'runner.ensure\',{},event)">Ensure Runner</button>';
+  html += '<button class="action-chip" onclick="doAction(\'runner.release-lock\',{},event)">Release Lock</button>';
+  html += '<button class="action-chip danger" onclick="doAction(\'runner.stop\',{reason:\'Dashboard operator\'},event)">Stop Runner</button>';
+  html += '</div>';
+
+  body.innerHTML = html || '<span style="font-size:11px;color:var(--muted)">No actions needed</span>';
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// EXPANDED DETAIL VIEWS
+// ═══════════════════════════════════════════════════════════════════
+
+function openExpanded(tileId){
+  expandedTile=tileId;
+  renderExpanded(tileId);
+  const overlay=document.getElementById('overlay');
+  overlay.classList.add('open');
+}
+
+function closeExpanded(){
+  expandedTile=null;
+  document.getElementById('overlay').classList.remove('open');
+}
+
+function renderExpanded(tileId){
+  if(!DATA) return;
+  const title=document.getElementById('overlayTitle');
+  const body=document.getElementById('overlayBody');
+  switch(tileId){
+    case 'health': renderExpandedHealth(title,body); break;
+    case 'fleet': renderExpandedFleet(title,body); break;
+    case 'cost': renderExpandedCost(title,body); break;
+    case 'alerts': renderExpandedAlerts(title,body); break;
+    case 'timeline': renderExpandedTimeline(title,body); break;
+    case 'git': renderExpandedGit(title,body); break;
+    case 'quality': renderExpandedQuality(title,body); break;
+    case 'connectivity': renderExpandedConnectivity(title,body); break;
+    case 'activeLanes': renderExpandedActiveLanes(title,body); break;
+    case 'tokens': renderExpandedTokens(title,body); break;
+    case 'actions': renderExpandedActions(title,body); break;
+    default: title.textContent='Details'; body.innerHTML='';
+  }
+}
+
+// ── Health Expanded ──
+function renderExpandedHealth(title,body){
+  title.textContent='System Health — Criteria';
+  const report=REPORT_DATA?.cycle_report||REPORT_DATA?.full_report||{};
+  const health=DATA.health?.health||{};
+  const collab=DATA.health?.collaboration||{};
+
+  // Try to find health criteria from report or health data
+  const criteria=report.criteria||report.health_criteria||health.criteria||[];
+  let html='';
+
+  if(Array.isArray(criteria)&&criteria.length>0){
+    html+='<div class="detail-list">';
+    criteria.forEach(c=>{
+      const pass=c.pass||c.status==='pass'||c.ok;
+      html+=`<div class="health-check">
+        <div class="check-icon ${pass?'pass':'fail'}">${pass?'\u2713':'\u2717'}</div>
+        <div class="check-name">${esc(c.name||c.criterion||c.label||'')}</div>
+        <div class="check-value">${esc(c.value||c.detail||'')}</div>
+      </div>`;
+    });
+    html+='</div>';
+  }else{
+    // Fallback: build from health + summary data
+    const alerts=DATA.alerts||[];
+    const s=DATA.summary||{};
+    const sc=s.status_counts||{};
+    const checks=[
+      {name:'Blocked Lanes',pass:(sc.blocked||0)===0,value:(sc.blocked||0)+' blocked'},
+      {name:'Active Lanes',pass:(sc.in_progress||0)>0,value:(sc.in_progress||0)+' active'},
+      {name:'Alert Count',pass:alerts.length===0,value:alerts.length+' alerts'},
+      {name:'High Severity Alerts',pass:!alerts.some(a=>a.severity==='high'),value:alerts.filter(a=>a.severity==='high').length+' high'},
+      {name:'Budget Utilization',pass:true,value:'$'+(s.total_cost_usd||0).toFixed(2)},
+      {name:'Total Lanes',pass:(s.lanes_total||0)>0,value:s.lanes_total||0},
+      {name:'Responses Generated',pass:(s.total_responses||0)>0,value:s.total_responses||0},
+    ];
+
+    // Add connectivity checks
+    const conn=DATA.connectivity||{};
+    const endpoints=conn.endpoints||[];
+    if(Array.isArray(endpoints)){
+      endpoints.forEach(ep=>{
+        const ok=ep.ok||ep.status==='ok';
+        checks.push({name:'Endpoint: '+(ep.id||ep.name||'?'),pass:ok,value:ok?'Connected':'Offline'});
+      });
+    }
+
+    // Add heartbeat checks for active lanes
+    (DATA.lanes||[]).filter(l=>l.status==='in_progress').forEach(l=>{
+      const age=l.heartbeat?.age_sec;
+      const stale=age!=null&&age>300;
+      checks.push({name:'Heartbeat: '+l.lane_id,pass:!stale,value:age!=null?age+'s':'N/A'});
+    });
+
+    html+='<div class="detail-list">';
+    checks.forEach(c=>{
+      html+=`<div class="health-check">
+        <div class="check-icon ${c.pass?'pass':'fail'}">${c.pass?'\u2713':'\u2717'}</div>
+        <div class="check-name">${esc(c.name)}</div>
+        <div class="check-value">${esc(String(c.value))}</div>
+      </div>`;
+    });
+    html+='</div>';
+  }
+
+  // Collaboration health
+  if(collab&&Object.keys(collab).length>0){
+    html+=`<div class="overlay-section">Collaboration Health</div>`;
+    html+='<div class="detail-grid">';
+    Object.entries(collab).forEach(([k,v])=>{
+      if(typeof v==='object') return;
+      html+=`<div class="detail-card"><div class="detail-card-label">${esc(k)}</div><div class="detail-card-val" style="font-size:14px;color:var(--text-secondary)">${esc(String(v))}</div></div>`;
+    });
+    html+='</div>';
+  }
+
+  body.innerHTML=html;
+}
+
+// ── Fleet Expanded ──
+function renderExpandedFleet(title,body){
+  title.textContent='Fleet Overview — Per-Owner Breakdown';
+  const lanes=DATA.lanes||[];
+  const grouped={};
+  lanes.forEach(l=>{
+    const o=l.owner||'unknown';
+    if(!grouped[o]) grouped[o]=[];
+    grouped[o].push(l);
+  });
+
+  let html='';
+  Object.entries(grouped).sort().forEach(([owner,ownerLanes])=>{
+    const color=OWNER_COLORS[owner]||'#64748b';
+    const counts={done:0,in_progress:0,pending:0,blocked:0,idle:0};
+    ownerLanes.forEach(l=>{if(counts[l.status]!==undefined)counts[l.status]++;});
+    const total=ownerLanes.length;
+
+    html+=`<div class="overlay-section" style="color:${color}">${esc(owner.toUpperCase())} \u2014 ${total} lanes</div>`;
+
+    // Summary bar
+    const segments=[
+      {status:'done',count:counts.done,label:'Done'},
+      {status:'in_progress',count:counts.in_progress,label:'Active'},
+      {status:'pending',count:counts.pending,label:'Pending'},
+      {status:'blocked',count:counts.blocked,label:'Blocked'},
+      {status:'idle',count:counts.idle,label:'Idle'},
+    ].filter(s=>s.count>0);
+
+    html+=`<div class="fleet-detail-bar">`;
+    segments.forEach(s=>{
+      const w=(s.count/total*100).toFixed(1);
+      const c=STATUS_COLORS[s.status]||'#64748b';
+      html+=`<div class="fleet-detail-seg" style="width:${w}%;background:${c}" title="${s.count} ${s.label}">${s.count>0?s.count:''}</div>`;
+    });
+    html+=`</div>`;
+
+    // Lane list
+    html+='<div class="detail-list">';
+    ownerLanes.forEach(l=>{
+      const sc=STATUS_COLORS[l.status]||'#64748b';
+      const tc=l.task_counts||{};
+      const total2=(tc.done||0)+(tc.in_progress||0)+(tc.pending||0)+(tc.blocked||0);
+      html+=`<div class="detail-list-item">
+        <div style="width:6px;height:6px;border-radius:50%;background:${sc};flex-shrink:0"></div>
+        <div style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(l.lane_id)}</div>
+        <div style="font-size:9px;color:var(--muted)">${tc.done||0}/${total2}</div>
+        <div style="font-size:9px;color:${sc};text-transform:uppercase;font-weight:600">${esc(l.status)}</div>
+      </div>`;
+    });
+    html+='</div>';
+  });
+
+  body.innerHTML=html;
+}
+
+// ── Cost Expanded ──
+function renderExpandedCost(title,body){
+  title.textContent='Cost Tracker — Detailed Breakdown';
+  const s=DATA.summary||{};
+  let html='';
+
+  html+='<div class="detail-grid">';
+  html+=`<div class="detail-card"><div class="detail-card-label">Total Cost</div><div class="detail-card-val" style="color:var(--text)">$${formatCost(s.total_cost_usd||0)}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Total Responses</div><div class="detail-card-val" style="color:var(--text)">${s.total_responses||0}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Total Tokens</div><div class="detail-card-val" style="color:var(--text)">${formatTokens(s.total_tokens||0)}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Active Lanes</div><div class="detail-card-val" style="color:var(--accent)">${(s.status_counts||{}).in_progress||0}</div></div>`;
+  html+='</div>';
+
+  // Hourly chart
+  if(COST_DATA&&COST_DATA.hourly_series&&COST_DATA.hourly_series.length>0){
+    html+=`<div class="overlay-section">Hourly Cost (24h)</div>`;
+    const series=COST_DATA.hourly_series;
+    const maxVal=Math.max(...series.map(d=>d.cost||d.value||0),0.01);
+    html+='<div class="cost-chart">';
+    series.forEach(d=>{
+      const v=d.cost||d.value||0;
+      const h=Math.max(2,(v/maxVal)*80);
+      const label=d.hour||d.label||'';
+      html+=`<div class="cost-chart-bar" style="height:${h}px"><div class="bar-tooltip">${esc(label)}: $${v.toFixed(4)}</div></div>`;
+    });
+    html+='</div>';
+  }
+
+  // By provider
+  if(COST_DATA&&COST_DATA.by_provider&&Object.keys(COST_DATA.by_provider).length>0){
+    html+=`<div class="overlay-section">By Provider</div>`;
+    html+='<div class="detail-list">';
+    Object.entries(COST_DATA.by_provider).sort((a,b)=>b[1]-a[1]).forEach(([k,v])=>{
+      html+=`<div class="detail-list-item"><div style="flex:1">${esc(k)}</div><div style="font-variant-numeric:tabular-nums">$${typeof v==='number'?v.toFixed(4):esc(String(v))}</div></div>`;
+    });
+    html+='</div>';
+  }
+
+  // By model
+  if(COST_DATA&&COST_DATA.by_model&&Object.keys(COST_DATA.by_model).length>0){
+    html+=`<div class="overlay-section">By Model</div>`;
+    html+='<div class="detail-list">';
+    Object.entries(COST_DATA.by_model).sort((a,b)=>b[1]-a[1]).forEach(([k,v])=>{
+      html+=`<div class="detail-list-item"><div style="flex:1;font-size:10px">${esc(k)}</div><div style="font-variant-numeric:tabular-nums">$${typeof v==='number'?v.toFixed(4):esc(String(v))}</div></div>`;
+    });
+    html+='</div>';
+  }
+
+  // Per-lane cost
+  const lanes=DATA.lanes||[];
+  const laneCosts=lanes.map(l=>({id:l.lane_id,cost:l.metrics?.cost_usd_total||0})).filter(l=>l.cost>0).sort((a,b)=>b.cost-a.cost);
+  if(laneCosts.length>0){
+    html+=`<div class="overlay-section">Per-Lane Cost</div>`;
+    html+='<div class="detail-list">';
+    laneCosts.forEach(l=>{
+      html+=`<div class="detail-list-item"><div style="flex:1;font-size:10px">${esc(l.id)}</div><div style="font-variant-numeric:tabular-nums">$${formatCost(l.cost)}</div></div>`;
+    });
+    html+='</div>';
+  }
+
+  body.innerHTML=html;
+}
+
+// ── Alerts Expanded ──
+function renderExpandedAlerts(title,body){
+  title.textContent='Alert Stack — Full Details';
+  const alerts=DATA.alerts||[];
+  if(alerts.length===0){
+    body.innerHTML='<div style="text-align:center;padding:40px;color:var(--muted)">No active alerts</div>';
+    return;
+  }
+  let html='<div class="detail-list">';
+  alerts.forEach(a=>{
+    const color=a.severity==='high'?'var(--critical)':a.severity==='medium'?'var(--warning)':'var(--accent)';
+    html+=`<div class="detail-list-item" style="border-left:3px solid ${color};flex-direction:column;align-items:flex-start;gap:4px">
+      <div style="display:flex;align-items:center;gap:8px;width:100%">
+        <span style="font-size:8px;font-weight:700;text-transform:uppercase;color:${color};letter-spacing:0.06em">${esc(a.severity||'')}</span>
+        <span style="font-size:9px;color:var(--muted);text-transform:uppercase">${esc(a.type||'')}</span>
+      </div>
+      <div style="font-size:11px;color:var(--text-secondary)">${esc(a.message||'')}</div>
+      ${a.lane_id?`<div style="font-size:9px;color:var(--muted)">Lane: ${esc(a.lane_id)}</div>`:''}
+    </div>`;
+  });
+  html+='</div>';
+  body.innerHTML=html;
+}
+
+// ── Timeline Expanded ──
+function renderExpandedTimeline(title,body){
+  title.textContent='Event Timeline — Full Feed';
+  const events=DATA.events||[];
+  if(events.length===0){
+    body.innerHTML='<div style="text-align:center;padding:40px;color:var(--muted)">No events</div>';
+    return;
+  }
+
+  // Type filter
+  const types=new Set();
+  events.forEach(e=>{const t=e.type||e.event_type||'';if(t)types.add(t);});
+
+  let html=`<div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:16px">`;
+  html+=`<button class="tl-filter-btn active" data-filter="all" style="font-size:9px;padding:4px 10px;border-radius:6px;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.06);color:var(--text);cursor:pointer">All</button>`;
+  types.forEach(t=>{
+    const c=EVT_COLORS[t]||'#64748b';
+    html+=`<button class="tl-filter-btn" data-filter="${esc(t)}" style="font-size:9px;padding:4px 10px;border-radius:6px;border:1px solid ${c}30;background:${c}10;color:${c};cursor:pointer">${esc(t)}</button>`;
+  });
+  html+=`</div>`;
+
+  html+='<div id="tlDetailList">';
+  events.forEach(evt=>{
+    const type=evt.type||evt.event_type||'';
+    const color=EVT_COLORS[type]||'#64748b';
+    const ts=evt.timestamp?evt.timestamp.slice(11,19):'';
+    const laneId=evt.lane_id||'';
+    const msgBody=evt.message||evt.summary||evt.body||type;
+    html+=`<div class="tl-detail-item" data-type="${esc(type)}">
+      <div class="tl-detail-dot" style="background:${color}"></div>
+      <div class="tl-detail-content">
+        <div style="display:flex;justify-content:space-between;align-items:center">
+          <div class="tl-detail-lane">${esc(laneId)}</div>
+          <div class="tl-detail-time">${esc(ts)}</div>
+        </div>
+        <div class="tl-detail-body">${esc(String(msgBody).slice(0,200))}</div>
+      </div>
+    </div>`;
+  });
+  html+='</div>';
+
+  body.innerHTML=html;
+
+  // Filter logic
+  body.querySelectorAll('.tl-filter-btn').forEach(btn=>{
+    btn.addEventListener('click',function(){
+      body.querySelectorAll('.tl-filter-btn').forEach(b=>b.classList.remove('active'));
+      this.classList.add('active');
+      const filter=this.getAttribute('data-filter');
+      body.querySelectorAll('.tl-detail-item').forEach(item=>{
+        if(filter==='all'||item.getAttribute('data-type')===filter){
+          item.style.display='';
+        }else{
+          item.style.display='none';
+        }
+      });
+    });
+  });
+}
+
+// ── Git Expanded ──
+function renderExpandedGit(title,body){
+  title.textContent='Git Pulse — Repository Details';
+  const git=DATA.git||{};
+  const commits=git.recent_commits||[];
+  const branches=git.branches||[];
+
+  let html='<div class="detail-grid">';
+  html+=`<div class="detail-card"><div class="detail-card-label">Current Branch</div><div class="detail-card-val" style="font-size:12px;color:var(--accent)">${esc(git.current_branch||'--')}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Total Branches</div><div class="detail-card-val" style="color:var(--text)">${git.branch_count||0}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Recent Commits</div><div class="detail-card-val" style="color:var(--text)">${commits.length}</div></div>`;
+  html+='</div>';
+
+  if(commits.length>0){
+    html+=`<div class="overlay-section">Recent Commits</div>`;
+    html+='<div class="detail-list">';
+    commits.forEach(c=>{
+      const authorColor=OWNER_COLORS[c.author]||'#64748b';
+      html+=`<div class="detail-list-item" style="flex-direction:column;align-items:flex-start;gap:3px">
+        <div style="display:flex;align-items:center;gap:8px;width:100%">
+          <span style="font-size:10px;font-weight:600;color:var(--accent);font-variant-numeric:tabular-nums">${esc((c.short_hash||c.hash||'').slice(0,7))}</span>
+          <span style="flex:1;font-size:11px;color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc((c.message||'').slice(0,80))}</span>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px">
+          <span style="font-size:9px;padding:1px 6px;border-radius:3px;background:${authorColor}15;color:${authorColor};font-weight:600">${esc(c.author||'')}</span>
+          <span style="font-size:9px;color:var(--muted)">${esc(c.relative_time||'')}</span>
+        </div>
+      </div>`;
+    });
+    html+='</div>';
+  }
+
+  if(branches.length>0){
+    html+=`<div class="overlay-section">Branches (${branches.length})</div>`;
+    html+='<div style="display:flex;flex-wrap:wrap;gap:4px">';
+    branches.slice(0,30).forEach(b=>{
+      const isCurrent=b===git.current_branch;
+      html+=`<span style="font-size:9px;padding:3px 8px;border-radius:4px;background:${isCurrent?'rgba(59,130,246,0.12)':'rgba(255,255,255,0.03)'};border:1px solid ${isCurrent?'rgba(59,130,246,0.3)':'rgba(255,255,255,0.04)'};color:${isCurrent?'var(--accent)':'var(--muted)'}">${esc(b)}</span>`;
+    });
+    if(branches.length>30) html+=`<span style="font-size:9px;padding:3px 8px;color:var(--muted)">+${branches.length-30} more</span>`;
+    html+='</div>';
+  }
+
+  body.innerHTML=html;
+}
+
+// ── Quality Expanded ──
+function renderExpandedQuality(title,body){
+  title.textContent='Response Quality — Per-Lane Breakdown';
+  const lanes=DATA.lanes||[];
+
+  let html='<div class="detail-list">';
+  lanes.filter(l=>(l.metrics?.responses_total||0)>0).sort((a,b)=>(b.metrics?.first_time_pass_rate||0)-(a.metrics?.first_time_pass_rate||0)).forEach(l=>{
+    const m=l.metrics||{};
+    const rate=m.first_time_pass_rate||0;
+    const pct=Math.round(rate*100);
+    const color=pct>=60?'var(--success)':pct>=40?'var(--warning)':'var(--critical)';
+    const ownerColor=OWNER_COLORS[l.owner]||'#64748b';
+    html+=`<div class="detail-list-item">
+      <div style="width:6px;height:6px;border-radius:50%;background:${ownerColor};flex-shrink:0"></div>
+      <div style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(l.lane_id)}</div>
+      <div style="font-size:10px;color:var(--muted)">${m.responses_total||0} resp</div>
+      <div style="font-size:13px;font-weight:700;color:${color};font-variant-numeric:tabular-nums;min-width:40px;text-align:right">${pct}%</div>
+    </div>`;
+  });
+  html+='</div>';
+
+  // Global metrics
+  const gm=DATA.metrics?.global||{};
+  if(Object.keys(gm).length>0){
+    html+=`<div class="overlay-section">Global Metrics</div>`;
+    html+='<div class="detail-grid">';
+    const metricKeys=[
+      ['responses_total','Responses'],
+      ['first_time_pass_rate','Pass Rate'],
+      ['acceptance_pass_rate','Accept Rate'],
+      ['latency_sec_avg','Avg Latency'],
+      ['token_rate_per_minute','Token Rate'],
+      ['routing_routellm_rate','RouteLLM Rate'],
+      ['routing_fallback_rate','Fallback Rate'],
+    ];
+    metricKeys.forEach(([k,label])=>{
+      let v=gm[k];
+      if(v==null) return;
+      let display;
+      if(typeof v==='number'){
+        if(k.includes('rate')) display=(v*100).toFixed(1)+'%';
+        else if(k.includes('latency')) display=v.toFixed(1)+'s';
+        else if(k.includes('token_rate')) display=Math.round(v)+'/min';
+        else display=v.toLocaleString();
+      }else{
+        display=String(v);
+      }
+      html+=`<div class="detail-card"><div class="detail-card-label">${esc(label)}</div><div class="detail-card-val" style="font-size:14px;color:var(--text)">${esc(display)}</div></div>`;
+    });
+    html+='</div>';
+  }
+
+  body.innerHTML=html;
+}
+
+// ── Connectivity Expanded ──
+function renderExpandedConnectivity(title,body){
+  title.textContent='Connectivity — Endpoint Status';
+  const conn=DATA.connectivity||{};
+  const endpoints=conn.endpoints||[];
+
+  if(!Array.isArray(endpoints)||endpoints.length===0){
+    body.innerHTML='<div style="text-align:center;padding:40px;color:var(--muted)">No endpoint data</div>';
+    return;
+  }
+
+  let html='<div class="detail-list">';
+  endpoints.forEach(ep=>{
+    const ok=ep.ok||ep.status==='ok';
+    html+=`<div class="detail-list-item" style="flex-direction:column;align-items:flex-start;gap:4px">
+      <div style="display:flex;align-items:center;gap:8px;width:100%">
+        <div class="conn-dot ${ok?'ok':'fail'}"></div>
+        <div style="font-weight:600;flex:1">${esc(ep.id||ep.name||'')}</div>
+        <div style="font-size:10px;font-weight:600;color:${ok?'var(--success)':'var(--critical)'}">${ok?'ONLINE':'OFFLINE'}</div>
+      </div>
+      <div style="display:flex;gap:16px;font-size:10px;color:var(--muted);padding-left:15px">
+        ${ep.latency!=null?`<span>Latency: ${ep.latency}ms</span>`:''}
+        ${ep.models!=null?`<span>Models: ${ep.models}</span>`:''}
+        ${ep.provider?`<span>Provider: ${esc(ep.provider)}</span>`:''}
+        ${ep.error?`<span style="color:var(--critical)">Error: ${esc(ep.error)}</span>`:''}
+      </div>
+    </div>`;
+  });
+  html+='</div>';
+
+  body.innerHTML=html;
+}
+
+// ── Active Lanes Expanded ──
+function renderExpandedActiveLanes(title,body){
+  title.textContent='Active Lanes — In-Progress Details';
+  const lanes=(DATA.lanes||[]).filter(l=>l.status==='in_progress');
+
+  if(lanes.length===0){
+    body.innerHTML='<div style="text-align:center;padding:40px;color:var(--muted)">No active lanes</div>';
+    return;
+  }
+
+  let html='';
+  lanes.forEach(lane=>{
+    const ownerColor=OWNER_COLORS[lane.owner]||'#64748b';
+    const tc=lane.task_counts||{};
+    const total=(tc.done||0)+(tc.in_progress||0)+(tc.pending||0)+(tc.blocked||0);
+    const done=tc.done||0;
+    const pct=total>0?(done/total*100):0;
+    const hb=lane.heartbeat||{};
+    const m=lane.metrics||{};
+
+    html+=`<div class="overlay-section" style="color:${ownerColor}">${esc(lane.lane_id)}</div>`;
+
+    html+='<div class="detail-grid">';
+    html+=`<div class="detail-card"><div class="detail-card-label">Progress</div><div class="detail-card-val" style="color:${ownerColor}">${done}/${total}</div></div>`;
+    html+=`<div class="detail-card"><div class="detail-card-label">Heartbeat</div><div class="detail-card-val" style="color:${(hb.age_sec||0)>120?'var(--warning)':'var(--text)'}">${hb.age_sec!=null&&hb.age_sec>=0?hb.age_sec+'s':'N/A'}</div></div>`;
+    html+=`<div class="detail-card"><div class="detail-card-label">Cost</div><div class="detail-card-val" style="color:var(--text)">$${formatCost(m.cost_usd_total||0)}</div></div>`;
+    html+=`<div class="detail-card"><div class="detail-card-label">Cycle</div><div class="detail-card-val" style="color:var(--text)">${hb.cycle||0}</div></div>`;
+    html+='</div>';
+
+    // Tasks
+    const tasks=lane.tasks||[];
+    if(tasks.length>0){
+      html+='<div class="detail-list">';
+      tasks.forEach(t=>{
+        const tsc=STATUS_COLORS[t.status]||'#64748b';
+        html+=`<div class="detail-list-item" style="border-left:2px solid ${tsc};flex-direction:column;align-items:flex-start;gap:2px">
+          <div style="display:flex;align-items:center;gap:6px;width:100%">
+            <span style="font-size:9px;font-weight:700;text-transform:uppercase;color:${tsc}">${esc(t.status)}</span>
+            <span style="font-size:10px;flex:1">${esc(t.task_id)}</span>
+            <span style="font-size:9px;color:var(--muted)">Attempts: ${t.attempts||0}</span>
+          </div>
+          ${t.last_summary?`<div style="font-size:10px;color:var(--text-secondary)">${esc(t.last_summary)}</div>`:''}
+          ${t.last_error?`<div style="font-size:10px;color:var(--critical)">${esc(t.last_error)}</div>`:''}
+        </div>`;
+      });
+      html+='</div>';
+    }
+
+    // Heartbeat message
+    if(hb.phase||hb.message){
+      html+=`<div style="font-size:10px;color:var(--text-secondary);padding:8px 10px;margin-top:8px;border-radius:8px;background:rgba(255,255,255,0.02)">`;
+      if(hb.phase) html+=`Phase: <span style="color:var(--accent)">${esc(hb.phase)}</span> &middot; `;
+      if(hb.message) html+=esc(hb.message);
+      html+=`</div>`;
+    }
+  });
+
+  body.innerHTML=html;
+}
+
+// ── Tokens Expanded ──
+function renderExpandedTokens(title,body){
+  title.textContent='Token Usage — Breakdown';
+  const s=DATA.summary||{};
+  const gm=DATA.metrics?.global||{};
+  const perLane=DATA.metrics?.per_lane||{};
+
+  let html='<div class="detail-grid">';
+  html+=`<div class="detail-card"><div class="detail-card-label">Total Tokens</div><div class="detail-card-val" style="color:var(--text)">${formatTokens(s.total_tokens||0)}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Token Rate</div><div class="detail-card-val" style="color:var(--text)">${gm.token_rate_per_minute?Math.round(gm.token_rate_per_minute)+'/min':'--'}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Total Responses</div><div class="detail-card-val" style="color:var(--text)">${s.total_responses||0}</div></div>`;
+  html+=`<div class="detail-card"><div class="detail-card-label">Avg Tokens/Response</div><div class="detail-card-val" style="color:var(--text)">${(s.total_responses||0)>0?formatTokens(Math.round((s.total_tokens||0)/(s.total_responses||1))):'--'}</div></div>`;
+  html+='</div>';
+
+  // Per-lane token usage
+  const laneTokens=Object.entries(perLane).map(([id,m])=>({id,tokens:m.tokens_total||0,responses:m.responses_total||0})).filter(l=>l.tokens>0).sort((a,b)=>b.tokens-a.tokens);
+
+  if(laneTokens.length>0){
+    html+=`<div class="overlay-section">Per-Lane Token Usage</div>`;
+    const maxTok=laneTokens[0].tokens||1;
+    html+='<div class="detail-list">';
+    laneTokens.forEach(l=>{
+      const pct=(l.tokens/maxTok*100).toFixed(1);
+      html+=`<div class="detail-list-item" style="flex-direction:column;gap:4px;align-items:stretch">
+        <div style="display:flex;justify-content:space-between;align-items:center">
+          <span style="font-size:10px">${esc(l.id)}</span>
+          <span style="font-size:10px;font-variant-numeric:tabular-nums;color:var(--text)">${formatTokens(l.tokens)}</span>
+        </div>
+        <div style="height:3px;border-radius:2px;background:rgba(255,255,255,0.04);overflow:hidden"><div style="width:${pct}%;height:100%;background:var(--accent);border-radius:2px"></div></div>
+      </div>`;
+    });
+    html+='</div>';
+  }
+
+  body.innerHTML=html;
+}
+
+// ── Actions Expanded ──
+function renderExpandedActions(title,body){
+  title.textContent='Actions — Operator Controls & Audit Trail';
+  let html='';
+
+  // Blocked tasks section
+  const blockedLanes = (DATA.lanes || []).filter(l => l.status === 'blocked');
+  const blockedTasks = [];
+  blockedLanes.forEach(l => {
+    (l.tasks || []).filter(t => t.status === 'blocked').forEach(t => {
+      blockedTasks.push({ lane_id: l.lane_id, task: t });
+    });
+  });
+
+  if (blockedTasks.length > 0) {
+    html += '<div class="overlay-section">Blocked Tasks</div>';
+    html += '<div class="detail-list">';
+    blockedTasks.forEach(({ lane_id, task }) => {
+      html += '<div class="detail-list-item" style="border-left:3px solid var(--critical);flex-direction:column;align-items:flex-start;gap:4px">';
+      html += '<div style="display:flex;align-items:center;gap:8px;width:100%">';
+      html += '<span style="font-size:10px;font-weight:600;color:var(--text)">' + esc(task.task_id) + '</span>';
+      html += '<span style="font-size:9px;color:var(--muted)">Lane: ' + esc(lane_id) + '</span>';
+      html += '<span style="margin-left:auto"><button class="action-chip" onclick="doAction(\'task.clear-error\',{task_id:\'' + esc(task.task_id) + '\'},event)">Clear & Retry</button></span>';
+      html += '</div>';
+      if (task.last_error) html += '<div style="font-size:10px;color:var(--critical)">' + esc(task.last_error) + '</div>';
+      html += '</div>';
+    });
+    html += '</div>';
+  }
+
+  // All available actions
+  html += '<div class="overlay-section">Quick Actions</div>';
+  html += '<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px">';
+  html += '<button class="action-chip" onclick="doAction(\'git.heal-locks\',{},event)">Heal Git Locks</button>';
+  html += '<button class="action-chip" onclick="doAction(\'runner.ensure\',{},event)">Ensure Runner</button>';
+  html += '<button class="action-chip" onclick="doAction(\'runner.release-lock\',{},event)">Release Lock</button>';
+  html += '<button class="action-chip danger" onclick="doAction(\'runner.stop\',{reason:\'Dashboard operator\'},event)">Stop Runner</button>';
+  html += '</div>';
+
+  // Action catalog
+  if (Actions.catalog && Actions.catalog.length > 0) {
+    html += '<div class="overlay-section">Action Catalog</div>';
+    html += '<div class="detail-list">';
+    Actions.catalog.forEach(a => {
+      const confirm = a.requires_confirmation ? '<span style="font-size:8px;color:var(--warning);margin-left:4px">CONFIRM</span>' : '';
+      html += '<div class="detail-list-item">';
+      html += '<div style="flex:1"><span style="font-size:11px;font-weight:600;color:var(--text)">' + esc(a.action_id) + '</span>' + confirm + '';
+      if (a.description) html += '<div style="font-size:10px;color:var(--muted)">' + esc(a.description) + '</div>';
+      html += '</div>';
+      html += '<button class="action-chip" onclick="doAction(\'' + esc(a.action_id) + '\',{},event)">Run</button>';
+      html += '</div>';
+    });
+    html += '</div>';
+  }
+
+  // Audit trail placeholder
+  html += '<div class="overlay-section">Audit Trail</div>';
+  html += '<div id="auditTrailList" style="font-size:11px;color:var(--muted)">Loading audit trail...</div>';
+
+  body.innerHTML = html;
+
+  // Fetch audit trail asynchronously
+  fetchJSON('/api/v2/audit-trail').then(data => {
+    const el = document.getElementById('auditTrailList');
+    if (!el) return;
+    const entries = Array.isArray(data) ? data : (data?.entries || []);
+    if (entries.length === 0) {
+      el.innerHTML = '<div style="color:var(--muted);opacity:0.5">No audit entries</div>';
+      return;
+    }
+    el.innerHTML = entries.slice(0, 50).map(e => {
+      const ts = e.timestamp ? e.timestamp.slice(11, 19) : '';
+      const ok = e.ok !== false;
+      return '<div class="audit-entry">' +
+        '<span style="color:var(--muted);font-variant-numeric:tabular-nums">' + esc(ts) + '</span> ' +
+        '<span style="color:' + (ok ? 'var(--success)' : 'var(--critical)') + ';font-weight:600">' + esc(e.action_id || e.action || '') + '</span> ' +
+        '<span style="color:var(--text-secondary)">' + esc((e.message || e.result || '').slice(0, 80)) + '</span>' +
+        '</div>';
+    }).join('');
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// EVENT BINDING
+// ═══════════════════════════════════════════════════════════════════
+
+// Tile clicks → expand
+document.querySelectorAll('.tile[data-tile]').forEach(tile=>{
+  tile.addEventListener('click',function(e){
+    const tileId=this.getAttribute('data-tile');
+    if(tileId) openExpanded(tileId);
+  });
+});
+
+// Overlay close
+document.getElementById('overlayClose').addEventListener('click',closeExpanded);
+document.getElementById('overlay').addEventListener('click',function(e){
+  if(e.target===this) closeExpanded();
+});
+
+// Keyboard
+document.addEventListener('keydown',function(e){
+  if(e.key==='Escape') closeExpanded();
+  if(e.key==='r'&&!e.ctrlKey&&!e.metaKey&&document.activeElement===document.body){
+    refreshData();
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BOOT
+// ═══════════════════════════════════════════════════════════════════
+
+Actions.loadCatalog();
+refreshData();
+setInterval(refreshData,POLL_MS);
+</script>
+</body>
+</html>

--- a/src/orxaq_autonomy/dashboard_v2_signal.html
+++ b/src/orxaq_autonomy/dashboard_v2_signal.html
@@ -1,0 +1,2165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SIGNAL — Command Interface</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%;overflow:hidden;background:#0a0a0a;font-family:'SF Mono','Fira Code','Cascadia Code','JetBrains Mono',monospace;color:#e0e0e0;-webkit-font-smoothing:antialiased}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar{width:4px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:#252525;border-radius:2px}
+::-webkit-scrollbar-thumb:hover{background:#333}
+
+/* ── Main layout ── */
+.signal-root{display:flex;flex-direction:column;height:100vh;align-items:center;justify-content:flex-start;padding-top:25vh;transition:padding-top 0.3s ease}
+.signal-root.has-results{padding-top:80px}
+
+/* ── Command bar ── */
+.cmd-wrap{width:100%;max-width:640px;padding:0 24px;position:relative;z-index:20;flex-shrink:0}
+.cmd-bar{position:relative;width:100%}
+.cmd-input{width:100%;background:#141414;border:1px solid #252525;border-radius:12px;padding:16px 20px;font-family:inherit;font-size:15px;color:#e0e0e0;outline:none;transition:border-color 0.2s,box-shadow 0.2s}
+.cmd-input:focus{border-color:#3b82f6;box-shadow:0 0 0 3px rgba(59,130,246,0.1),0 0 20px rgba(59,130,246,0.05)}
+.cmd-input::placeholder{color:#444}
+.cmd-ghost{position:absolute;top:0;left:0;right:0;bottom:0;padding:16px 20px;font-family:inherit;font-size:15px;color:#333;pointer-events:none;white-space:nowrap;overflow:hidden}
+
+/* ── Autocomplete dropdown ── */
+.ac-dropdown{position:absolute;top:100%;left:0;right:0;background:#141414;border:1px solid #252525;border-top:none;border-radius:0 0 12px 12px;max-height:280px;overflow-y:auto;z-index:30;display:none}
+.ac-dropdown.open{display:block}
+.ac-item{padding:10px 20px;display:flex;justify-content:space-between;align-items:center;cursor:pointer;transition:background 0.1s;font-size:13px}
+.ac-item:hover,.ac-item.focused{background:#1a1a1a}
+.ac-item .ac-cmd{color:#3b82f6;font-weight:600}
+.ac-item .ac-alias{color:#555;margin-left:8px;font-size:11px}
+.ac-item .ac-desc{color:#555;font-size:11px;text-align:right;flex-shrink:0;margin-left:16px}
+
+/* ── Results area ── */
+.results-wrap{width:100%;max-width:640px;padding:0 24px;margin-top:12px;flex:1;overflow-y:auto;overflow-x:hidden;z-index:10}
+.results-count{font-size:10px;color:#555;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:8px;padding:0 4px;display:flex;justify-content:space-between;align-items:center}
+.results-list{display:flex;flex-direction:column;gap:4px;padding-bottom:60px}
+
+/* ── Result card ── */
+.card{background:#111;border:1px solid #1e1e1e;border-radius:8px;overflow:hidden;transition:border-color 0.2s,background 0.15s;cursor:pointer}
+.card:hover{border-color:#2a2a2a;background:#131313}
+.card.focused{border-color:#3b82f6;background:#111318}
+.card.expanded{cursor:default}
+.card-header{display:flex;align-items:center;gap:10px;padding:12px 16px;min-height:44px}
+.card-icon{font-size:13px;flex-shrink:0;width:20px;text-align:center;opacity:0.7}
+.card-title{flex:1;font-size:13px;color:#e0e0e0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.card-stat{font-size:11px;color:#888;flex-shrink:0;font-variant-numeric:tabular-nums}
+.card-chevron{font-size:10px;color:#444;flex-shrink:0;transition:transform 0.2s}
+.card.expanded .card-chevron{transform:rotate(90deg)}
+
+/* ── Card body (expanded) ── */
+.card-body{max-height:0;overflow:hidden;transition:max-height 0.25s ease,padding 0.25s ease}
+.card.expanded .card-body{max-height:2000px}
+.card-body-inner{padding:0 16px 16px;border-top:1px solid #1a1a1a}
+
+/* ── Badges ── */
+.badge{display:inline-block;font-size:9px;padding:2px 7px;border-radius:4px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;line-height:1.4;vertical-align:middle}
+.badge-success{background:rgba(16,185,129,0.12);color:#10b981;border:1px solid rgba(16,185,129,0.2)}
+.badge-warning{background:rgba(245,158,11,0.12);color:#f59e0b;border:1px solid rgba(245,158,11,0.2)}
+.badge-critical{background:rgba(239,68,68,0.12);color:#ef4444;border:1px solid rgba(239,68,68,0.2)}
+.badge-info{background:rgba(59,130,246,0.12);color:#3b82f6;border:1px solid rgba(59,130,246,0.2)}
+.badge-muted{background:rgba(85,85,85,0.15);color:#777;border:1px solid rgba(85,85,85,0.2)}
+.badge-owner{font-size:8px;padding:1px 5px;border-radius:3px;font-weight:700;letter-spacing:0.06em}
+
+/* ── Status badge helper ── */
+.status-done{background:rgba(16,185,129,0.12);color:#10b981;border:1px solid rgba(16,185,129,0.2)}
+.status-in_progress,.status-active{background:rgba(59,130,246,0.12);color:#3b82f6;border:1px solid rgba(59,130,246,0.2)}
+.status-blocked{background:rgba(239,68,68,0.12);color:#ef4444;border:1px solid rgba(239,68,68,0.2)}
+.status-pending{background:rgba(245,158,11,0.12);color:#f59e0b;border:1px solid rgba(245,158,11,0.2)}
+.status-idle{background:rgba(85,85,85,0.15);color:#777;border:1px solid rgba(85,85,85,0.2)}
+
+/* ── Metric grid ── */
+.metric-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:12px}
+@media(max-width:600px){.metric-grid{grid-template-columns:repeat(2,1fr)}}
+.metric-cell{background:#0e0e0e;border:1px solid #1a1a1a;border-radius:6px;padding:10px 12px;text-align:center}
+.metric-label{font-size:8px;color:#555;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:4px}
+.metric-value{font-size:18px;font-weight:700;color:#e0e0e0;font-variant-numeric:tabular-nums}
+.metric-value.ok{color:#10b981}
+.metric-value.warn{color:#f59e0b}
+.metric-value.crit{color:#ef4444}
+.metric-value.info{color:#3b82f6}
+
+/* ── Detail tables ── */
+.detail-section{margin-top:14px}
+.detail-section-title{font-size:9px;color:#555;text-transform:uppercase;letter-spacing:0.12em;margin-bottom:8px;padding-bottom:4px;border-bottom:1px solid #1a1a1a}
+.detail-row{display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid #0e0e0e;font-size:12px}
+.detail-row:last-child{border-bottom:none}
+.detail-key{color:#777;font-size:11px}
+.detail-val{color:#e0e0e0;font-size:12px;text-align:right;max-width:60%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-variant-numeric:tabular-nums}
+
+/* ── Task list inside lane card ── */
+.task-item{display:flex;align-items:flex-start;gap:8px;padding:8px 10px;margin:3px 0;background:#0c0c0c;border-radius:4px;border-left:2px solid #1a1a1a;font-size:11px}
+.task-item.task-done{border-left-color:#10b981}
+.task-item.task-in_progress{border-left-color:#3b82f6}
+.task-item.task-blocked{border-left-color:#ef4444}
+.task-item.task-pending{border-left-color:#f59e0b}
+.task-id{color:#3b82f6;font-weight:600;white-space:nowrap;flex-shrink:0}
+.task-summary{color:#999;flex:1;overflow:hidden;text-overflow:ellipsis}
+.task-meta{color:#555;font-size:10px;white-space:nowrap;flex-shrink:0}
+
+/* ── Health criterion row ── */
+.health-row{display:flex;align-items:center;gap:10px;padding:8px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:12px}
+.health-indicator{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.health-indicator.pass{background:#10b981}
+.health-indicator.fail{background:#ef4444}
+.health-indicator.warn{background:#f59e0b}
+.health-name{flex:1;color:#ccc}
+.health-status{flex-shrink:0}
+
+/* ── Commit row ── */
+.commit-row{display:flex;align-items:flex-start;gap:10px;padding:8px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:12px}
+.commit-hash{color:#3b82f6;font-size:11px;font-weight:600;flex-shrink:0}
+.commit-msg{flex:1;color:#ccc;overflow:hidden;text-overflow:ellipsis}
+.commit-meta{color:#555;font-size:10px;flex-shrink:0;text-align:right;white-space:nowrap}
+
+/* ── Event row ── */
+.event-row{display:flex;align-items:flex-start;gap:8px;padding:7px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:11px}
+.event-time{color:#444;font-size:10px;flex-shrink:0;font-variant-numeric:tabular-nums;min-width:50px}
+.event-body{flex:1;color:#999}
+.event-lane{color:#555;font-size:10px;flex-shrink:0}
+
+/* ── Highlight ── */
+.hl{background:rgba(59,130,246,0.2);border-radius:2px;padding:0 1px}
+
+/* ── Progress bar ── */
+.progress{height:4px;background:#1a1a1a;border-radius:2px;overflow:hidden;margin-top:6px}
+.progress-fill{height:100%;border-radius:2px;transition:width 0.3s}
+.progress-fill.ok{background:#10b981}
+.progress-fill.info{background:#3b82f6}
+.progress-fill.warn{background:#f59e0b}
+.progress-fill.crit{background:#ef4444}
+
+/* ── Shimmer loading ── */
+.shimmer{position:relative;overflow:hidden;background:#111;border-radius:8px;height:44px;margin-bottom:4px}
+.shimmer::after{content:'';position:absolute;top:0;left:-100%;width:100%;height:100%;background:linear-gradient(90deg,transparent,rgba(255,255,255,0.02),transparent);animation:shimmer 1.5s infinite}
+@keyframes shimmer{to{left:100%}}
+
+/* ── Status line ── */
+.status-line{position:fixed;bottom:0;left:0;right:0;text-align:center;padding:10px;font-size:10px;color:#333;z-index:5;letter-spacing:0.06em}
+.status-line .conn-ok{color:#10b981}
+.status-line .conn-err{color:#ef4444}
+.status-line .sep{color:#222;margin:0 8px}
+
+/* ── Help overlay ── */
+.help-grid{display:grid;grid-template-columns:1fr 1fr;gap:4px}
+@media(max-width:500px){.help-grid{grid-template-columns:1fr}}
+.help-item{display:flex;gap:10px;padding:6px 10px;background:#0c0c0c;border-radius:4px;font-size:12px}
+.help-cmd{color:#3b82f6;font-weight:600;min-width:90px;flex-shrink:0}
+.help-desc{color:#777}
+
+/* ── Owner colors ── */
+.owner-codex{background:rgba(0,200,255,0.12);color:#00c8ff;border:1px solid rgba(0,200,255,0.25)}
+.owner-gemini{background:rgba(255,136,0,0.12);color:#ff8800;border:1px solid rgba(255,136,0,0.25)}
+.owner-claude{background:rgba(168,85,247,0.12);color:#a855f7;border:1px solid rgba(168,85,247,0.25)}
+.owner-unknown{background:rgba(90,122,138,0.12);color:#5a7a8a;border:1px solid rgba(90,122,138,0.25)}
+
+/* ── Connectivity endpoint row ── */
+.conn-row{display:flex;align-items:center;gap:10px;padding:8px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:12px}
+.conn-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.conn-dot.up{background:#10b981}
+.conn-dot.down{background:#ef4444}
+.conn-dot.unknown{background:#555}
+.conn-name{flex:1;color:#ccc}
+.conn-latency{color:#555;font-size:11px;flex-shrink:0;font-variant-numeric:tabular-nums}
+
+/* ── Policy row ── */
+.policy-row{display:flex;align-items:center;gap:10px;padding:8px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:12px}
+.policy-name{flex:1;color:#ccc;text-transform:capitalize}
+
+/* ── Privilege detail ── */
+.priv-row{display:flex;justify-content:space-between;align-items:center;padding:6px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:12px}
+.priv-key{color:#777}
+.priv-val{color:#e0e0e0;font-weight:600}
+
+/* ── Backlog task ── */
+.backlog-task{padding:8px 10px;margin:2px 0;background:#0c0c0c;border-radius:4px;font-size:12px;border-left:2px solid #1a1a1a}
+.backlog-task .bt-id{color:#3b82f6;font-weight:600}
+.backlog-task .bt-desc{color:#999;margin-top:2px}
+.backlog-task .bt-meta{display:flex;gap:8px;margin-top:4px;font-size:10px;color:#555}
+
+/* ── Empty state ── */
+.empty-state{text-align:center;padding:40px 20px;color:#333;font-size:13px}
+.empty-state .empty-icon{font-size:24px;margin-bottom:8px;opacity:0.4}
+.empty-state .empty-hint{font-size:11px;color:#2a2a2a;margin-top:6px}
+
+/* ── Action confirm buttons ── */
+.action-confirm-btn {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border, #252525);
+  border-radius: 6px;
+  padding: 6px 16px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.confirm-yes {
+  background: rgba(59,130,246,0.15);
+  color: #3b82f6;
+  border-color: rgba(59,130,246,0.3);
+}
+.confirm-yes:hover { background: rgba(59,130,246,0.25); }
+.confirm-no {
+  background: transparent;
+  color: #555;
+}
+.confirm-no:hover { background: rgba(255,255,255,0.05); }
+</style>
+</head>
+<body>
+
+<div class="signal-root" id="root">
+  <!-- Command bar -->
+  <div class="cmd-wrap">
+    <div class="cmd-bar" id="cmd-bar">
+      <div class="cmd-ghost" id="cmd-ghost"></div>
+      <input type="text" class="cmd-input" id="cmd-input"
+             placeholder="Type a command or search... (try /status, /blocked, /cost)"
+             autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+      <div class="ac-dropdown" id="ac-dropdown"></div>
+    </div>
+  </div>
+
+  <!-- Results -->
+  <div class="results-wrap" id="results-wrap" style="display:none">
+    <div class="results-count" id="results-count"></div>
+    <div class="results-list" id="results-list"></div>
+  </div>
+</div>
+
+<!-- Status line -->
+<div class="status-line" id="status-line">
+  &#x2500;&#x2500;&#x2500; signal &#x00b7; connecting... &#x2500;&#x2500;&#x2500;
+</div>
+
+<script>
+// =====================================================================
+// STATE
+// =====================================================================
+const S = {
+  snapshot: null,
+  report: null,
+  costSeries: null,
+  privileges: null,
+  policies: null,
+  backlog: null,
+  responseStream: null,
+  lastRefresh: 0,
+  connected: false,
+  error: null,
+  searchIndex: [],
+  commandHistory: [],
+  historyPos: -1,
+  focusedCard: -1,
+  expandedCards: new Set(),
+  currentQuery: '',
+  currentResults: [],
+};
+
+// =====================================================================
+// HTML ESCAPING
+// =====================================================================
+const _escDiv = document.createElement('div');
+function esc(s) {
+  if (s == null) return '';
+  _escDiv.textContent = String(s);
+  return _escDiv.innerHTML;
+}
+
+// =====================================================================
+// COMMANDS REGISTRY
+// =====================================================================
+const COMMANDS = [
+  { cmd: '/status',       aliases: ['/s'],      desc: 'Full swarm status overview' },
+  { cmd: '/blocked',      aliases: ['/b'],      desc: 'Show all blocked lanes' },
+  { cmd: '/alerts',       aliases: ['/a'],      desc: 'Show all active alerts' },
+  { cmd: '/cost',         aliases: [],          desc: 'Cost breakdown and trends' },
+  { cmd: '/lanes',        aliases: [],          desc: 'All lanes grouped by status' },
+  { cmd: '/lane',         aliases: [],          desc: 'Specific lane detail (fuzzy match)' },
+  { cmd: '/health',       aliases: [],          desc: '19 health criteria with pass/fail' },
+  { cmd: '/git',          aliases: [],          desc: 'Git state and recent commits' },
+  { cmd: '/events',       aliases: ['/e'],      desc: 'Recent event stream' },
+  { cmd: '/owners',       aliases: [],          desc: 'Per-owner summary' },
+  { cmd: '/connectivity', aliases: ['/conn'],   desc: 'Model endpoint status' },
+  { cmd: '/privileges',   aliases: ['/priv'],   desc: 'Privilege state and escalations' },
+  { cmd: '/policies',     aliases: [],          desc: 'Policy compliance status' },
+  { cmd: '/backlog',      aliases: [],          desc: 'Task backlog overview' },
+  { cmd: '/metrics',      aliases: [],          desc: 'Response metrics (pass rate, latency)' },
+  { cmd: '/responses',    aliases: [],          desc: 'Recent individual response metrics' },
+  { cmd: '/help',         aliases: ['/h'],      desc: 'Show all available commands' },
+  { cmd: '/unblock',      aliases: ['/ub'],      desc: 'Clear error & retry a blocked task' },
+  { cmd: '/reprioritize', aliases: ['/reprio'],   desc: 'Change task priority' },
+  { cmd: '/grant',        aliases: [],            desc: 'Issue a breakglass grant' },
+  { cmd: '/revoke',       aliases: [],            desc: 'Revoke a breakglass grant' },
+  { cmd: '/heal',         aliases: ['/heal-locks'], desc: 'Remove stale git lock files' },
+  { cmd: '/stop',         aliases: [],            desc: 'Stop the autonomy runner' },
+  { cmd: '/start',        aliases: [],            desc: 'Start the autonomy runner' },
+  { cmd: '/ensure',       aliases: [],            desc: 'Ensure runner is alive' },
+  { cmd: '/release-lock', aliases: [],            desc: 'Remove stale runner lock' },
+  { cmd: '/audit',        aliases: [],            desc: 'Show recent action audit trail' },
+  { cmd: '/actions',      aliases: [],            desc: 'List available operator actions' },
+];
+
+// =====================================================================
+// FUZZY SEARCH
+// =====================================================================
+function fuzzyScore(query, text) {
+  if (!query || !text) return 0;
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+
+  // Exact match
+  if (t === q) return 1000;
+
+  // Starts with
+  if (t.startsWith(q)) return 800 + (q.length / t.length) * 100;
+
+  // Word boundary match (query matches start of a word in text)
+  const words = t.split(/[\s\-_./]+/);
+  for (let i = 0; i < words.length; i++) {
+    if (words[i].startsWith(q)) return 600 + (q.length / t.length) * 100;
+  }
+
+  // Substring match
+  const idx = t.indexOf(q);
+  if (idx >= 0) return 400 + (q.length / t.length) * 100 - idx * 0.5;
+
+  // Character sequence match (all chars of query appear in order in text)
+  let qi = 0;
+  let consecutiveBonus = 0;
+  let lastMatchIdx = -2;
+  let matchCount = 0;
+  let firstMatchIdx = -1;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      if (firstMatchIdx === -1) firstMatchIdx = ti;
+      if (ti === lastMatchIdx + 1) consecutiveBonus += 20;
+      // Word boundary bonus
+      if (ti === 0 || /[\s\-_./]/.test(t[ti - 1])) consecutiveBonus += 15;
+      lastMatchIdx = ti;
+      matchCount++;
+      qi++;
+    }
+  }
+  if (qi === q.length) {
+    const coverage = matchCount / t.length;
+    return 100 + consecutiveBonus + coverage * 80 - firstMatchIdx * 0.3;
+  }
+
+  return 0;
+}
+
+function highlightMatch(text, query) {
+  if (!query || !text) return esc(text);
+  const t = String(text);
+  const q = query.toLowerCase();
+  const tl = t.toLowerCase();
+  const idx = tl.indexOf(q);
+  if (idx >= 0) {
+    return esc(t.substring(0, idx)) +
+      '<span class="hl">' + esc(t.substring(idx, idx + q.length)) + '</span>' +
+      esc(t.substring(idx + q.length));
+  }
+  return esc(t);
+}
+
+// =====================================================================
+// SEARCH INDEX BUILDER
+// =====================================================================
+function buildSearchIndex() {
+  const idx = [];
+  const snap = S.snapshot;
+  if (!snap) return idx;
+
+  // Lanes
+  (snap.lanes || []).forEach(lane => {
+    idx.push({
+      type: 'lane', data: lane,
+      fields: [
+        { key: 'lane_id', val: lane.lane_id },
+        { key: 'owner', val: lane.owner },
+        { key: 'status', val: lane.status },
+      ]
+    });
+    // Tasks within lanes
+    (lane.tasks || []).forEach(task => {
+      idx.push({
+        type: 'task', data: { ...task, lane_id: lane.lane_id, lane_owner: lane.owner },
+        fields: [
+          { key: 'task_id', val: task.task_id },
+          { key: 'summary', val: task.last_summary },
+          { key: 'lane_id', val: lane.lane_id },
+          { key: 'owner', val: task.owner },
+        ]
+      });
+    });
+  });
+
+  // Alerts
+  (snap.alerts || []).forEach(alert => {
+    idx.push({
+      type: 'alert', data: alert,
+      fields: [
+        { key: 'message', val: alert.message },
+        { key: 'type', val: alert.type },
+        { key: 'lane_id', val: alert.lane_id || '' },
+      ]
+    });
+  });
+
+  // Events
+  (snap.events || []).forEach(evt => {
+    idx.push({
+      type: 'event', data: evt,
+      fields: [
+        { key: 'message', val: evt.message || evt.event || '' },
+        { key: 'type', val: evt.type || evt.event || '' },
+        { key: 'lane_id', val: evt.lane_id || '' },
+      ]
+    });
+  });
+
+  // Git commits
+  const git = snap.git || {};
+  (git.recent_commits || []).forEach(c => {
+    idx.push({
+      type: 'commit', data: c,
+      fields: [
+        { key: 'message', val: c.message },
+        { key: 'author', val: c.author },
+        { key: 'hash', val: c.short_hash },
+      ]
+    });
+  });
+
+  // Endpoints
+  const conn = snap.connectivity || {};
+  Object.entries(conn).forEach(([name, info]) => {
+    if (typeof info !== 'object' || !info) return;
+    idx.push({
+      type: 'endpoint', data: { name, ...info },
+      fields: [
+        { key: 'name', val: name },
+        { key: 'status', val: info.status || '' },
+      ]
+    });
+  });
+
+  S.searchIndex = idx;
+  return idx;
+}
+
+function searchIndex(query) {
+  const results = [];
+  const q = query.trim().toLowerCase();
+  if (!q) return results;
+
+  for (const entry of S.searchIndex) {
+    let bestScore = 0;
+    let bestField = '';
+    for (const f of entry.fields) {
+      const score = fuzzyScore(q, f.val || '');
+      if (score > bestScore) {
+        bestScore = score;
+        bestField = f.key;
+      }
+    }
+    if (bestScore > 0) {
+      results.push({ ...entry, score: bestScore, matchedField: bestField });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, 50);
+}
+
+// =====================================================================
+// DATA FETCHING
+// =====================================================================
+async function fetchJSON(url) {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error('HTTP ' + resp.status);
+  return resp.json();
+}
+
+async function fetchAll() {
+  try {
+    const snap = await fetchJSON('/api/v2/snapshot');
+    S.snapshot = snap;
+    S.connected = true;
+    S.error = null;
+    S.lastRefresh = Date.now();
+    buildSearchIndex();
+    updateStatusLine();
+    // If there's a current query, re-run it
+    if (S.currentQuery) executeQuery(S.currentQuery);
+  } catch (e) {
+    S.connected = false;
+    S.error = e.message;
+    updateStatusLine();
+  }
+}
+
+async function fetchSecondary() {
+  const jobs = [
+    fetchJSON('/api/v2/report').then(d => S.report = d).catch(() => {}),
+    fetchJSON('/api/v2/cost-series').then(d => S.costSeries = d).catch(() => {}),
+    fetchJSON('/api/v2/privileges').then(d => S.privileges = d).catch(() => {}),
+    fetchJSON('/api/v2/policies').then(d => S.policies = d).catch(() => {}),
+    fetchJSON('/api/v2/task-backlog').then(d => S.backlog = d).catch(() => {}),
+    fetchJSON('/api/v2/response-stream').then(d => S.responseStream = d).catch(() => {}),
+  ];
+  await Promise.allSettled(jobs);
+}
+
+// Polling
+let primaryTimer = null;
+let secondaryTimer = null;
+
+function startPolling() {
+  fetchAll();
+  fetchSecondary();
+  primaryTimer = setInterval(fetchAll, 10000);
+  secondaryTimer = setInterval(fetchSecondary, 30000);
+}
+
+// =====================================================================
+// ACTIONS API
+// =====================================================================
+const Actions = {
+  catalog: null,
+  async loadCatalog() {
+    try {
+      const r = await fetch('/api/v2/actions');
+      if (r.ok) this.catalog = await r.json();
+    } catch(e) {}
+    return this.catalog;
+  },
+  async execute(actionId, params = {}, { dryRun = false, confirmToken = '' } = {}) {
+    const r = await fetch('/api/v2/actions/' + actionId, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ params, dry_run: dryRun, confirm_token: confirmToken }),
+    });
+    return r.json();
+  }
+};
+
+// =====================================================================
+// STATUS LINE
+// =====================================================================
+function updateStatusLine() {
+  const el = document.getElementById('status-line');
+  const age = S.lastRefresh ? Math.round((Date.now() - S.lastRefresh) / 1000) : 0;
+  const ageStr = age < 5 ? 'just now' : age + 's ago';
+  if (S.connected) {
+    el.innerHTML = '\u2500\u2500\u2500 signal <span class="sep">\u00b7</span> <span class="conn-ok">connected</span> <span class="sep">\u00b7</span> refreshed ' + esc(ageStr) + ' \u2500\u2500\u2500';
+  } else {
+    el.innerHTML = '\u2500\u2500\u2500 signal <span class="sep">\u00b7</span> <span class="conn-err">disconnected</span>' + (S.error ? ' <span class="sep">\u00b7</span> ' + esc(S.error) : '') + ' \u2500\u2500\u2500';
+  }
+}
+
+// Keep refreshing status line age
+setInterval(updateStatusLine, 5000);
+
+// =====================================================================
+// FORMATTING HELPERS
+// =====================================================================
+function fmtTokens(n) {
+  n = Number(n) || 0;
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(0) + 'K';
+  return String(n);
+}
+
+function fmtCost(n) {
+  n = Number(n) || 0;
+  return '$' + n.toFixed(2);
+}
+
+function fmtPct(n) {
+  n = Number(n) || 0;
+  return (n * 100).toFixed(0) + '%';
+}
+
+function fmtTime(ts) {
+  if (!ts) return '';
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return String(ts).substring(0, 19);
+    const now = Date.now();
+    const diffSec = Math.floor((now - d.getTime()) / 1000);
+    if (diffSec < 60) return diffSec + 's ago';
+    if (diffSec < 3600) return Math.floor(diffSec / 60) + 'm ago';
+    if (diffSec < 86400) return Math.floor(diffSec / 3600) + 'h ago';
+    return Math.floor(diffSec / 86400) + 'd ago';
+  } catch (e) {
+    return String(ts).substring(0, 19);
+  }
+}
+
+function fmtTimeShort(ts) {
+  if (!ts) return '';
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+  } catch (e) {
+    return '';
+  }
+}
+
+function statusBadge(status) {
+  const cls = 'status-' + (status || 'unknown').replace(/\s/g, '_');
+  return '<span class="badge ' + cls + '">' + esc(status || 'unknown') + '</span>';
+}
+
+function ownerBadge(owner) {
+  const o = (owner || 'unknown').toLowerCase();
+  const cls = 'owner-' + (['codex', 'gemini', 'claude'].includes(o) ? o : 'unknown');
+  return '<span class="badge badge-owner ' + cls + '">' + esc(owner || 'unknown') + '</span>';
+}
+
+function severityBadge(severity) {
+  const map = { high: 'badge-critical', medium: 'badge-warning', low: 'badge-info' };
+  return '<span class="badge ' + (map[severity] || 'badge-muted') + '">' + esc(severity) + '</span>';
+}
+
+function cardIcon(type) {
+  const icons = {
+    status: '\u25c8', lane: '\u25cf', alert: '\u26a0', event: '\u25b8',
+    commit: '\u25cb', metric: '\u25a0', health: '\u2713', task: '\u25aa',
+    endpoint: '\u25c9', owner: '\u25c6', help: '\u003f', privilege: '\u26bf',
+    policy: '\u25a3', backlog: '\u2630', response: '\u25b7', cost: '\u25b2',
+  };
+  return icons[type] || '\u25cf';
+}
+
+// =====================================================================
+// COMMAND EXECUTION
+// =====================================================================
+function executeQuery(raw) {
+  const q = raw.trim();
+  if (!q) {
+    clearResults();
+    return;
+  }
+  S.currentQuery = q;
+
+  // Add to history
+  if (!S.commandHistory.length || S.commandHistory[S.commandHistory.length - 1] !== q) {
+    S.commandHistory.push(q);
+  }
+  S.historyPos = -1;
+
+  // Parse command
+  if (q.startsWith('/')) {
+    const parts = q.split(/\s+/);
+    const cmd = parts[0].toLowerCase();
+    const arg = parts.slice(1).join(' ');
+    executeCommand(cmd, arg);
+  } else {
+    executeFuzzySearch(q);
+  }
+}
+
+function executeCommand(cmd, arg) {
+  // Resolve aliases
+  const entry = COMMANDS.find(c => c.cmd === cmd || c.aliases.includes(cmd));
+  const resolved = entry ? entry.cmd : cmd;
+
+  switch (resolved) {
+    case '/status': renderStatus(); break;
+    case '/blocked': renderBlocked(); break;
+    case '/alerts': renderAlerts(); break;
+    case '/cost': renderCost(); break;
+    case '/lanes': renderLanes(); break;
+    case '/lane': renderLane(arg); break;
+    case '/health': renderHealth(); break;
+    case '/git': renderGit(); break;
+    case '/events': renderEvents(); break;
+    case '/owners': renderOwners(); break;
+    case '/connectivity': renderConnectivity(); break;
+    case '/privileges': renderPrivileges(); break;
+    case '/policies': renderPolicies(); break;
+    case '/backlog': renderBacklog(); break;
+    case '/metrics': renderMetrics(); break;
+    case '/responses': renderResponses(); break;
+    case '/help': renderHelp(); break;
+    case '/unblock': handleUnblock(arg); break;
+    case '/reprioritize': handleReprioritize(arg); break;
+    case '/grant': handleGrant(arg); break;
+    case '/revoke': handleRevoke(arg); break;
+    case '/heal': executeAction('git.heal-locks'); break;
+    case '/stop': executeAction('runner.stop'); break;
+    case '/start': executeAction('runner.start'); break;
+    case '/ensure': executeAction('runner.ensure'); break;
+    case '/release-lock': executeAction('runner.release-lock'); break;
+    case '/audit': renderAudit(); break;
+    case '/actions': renderActionsCatalog(); break;
+    default:
+      showResults([{ html: noDataCard('Unknown command: ' + esc(cmd), 'Try /help for available commands') }], 'Unknown Command');
+  }
+}
+
+function executeFuzzySearch(query) {
+  const results = searchIndex(query);
+  if (!results.length) {
+    showResults([{ html: noDataCard('No results for "' + esc(query) + '"', 'Try a different search term or use /help') }], '0 Results');
+    return;
+  }
+
+  const cards = results.map((r, i) => {
+    switch (r.type) {
+      case 'lane': return { html: laneCardHTML(r.data, query), id: 'search-' + i };
+      case 'task': return { html: taskSearchCardHTML(r.data, query), id: 'search-' + i };
+      case 'alert': return { html: alertCardHTML(r.data, query), id: 'search-' + i };
+      case 'event': return { html: eventCardHTML(r.data, query), id: 'search-' + i };
+      case 'commit': return { html: commitCardHTML(r.data, query), id: 'search-' + i };
+      case 'endpoint': return { html: endpointCardHTML(r.data, query), id: 'search-' + i };
+      default: return { html: genericCardHTML(r), id: 'search-' + i };
+    }
+  });
+
+  showResults(cards, results.length + ' Result' + (results.length === 1 ? '' : 's'));
+}
+
+// =====================================================================
+// RESULT RENDERING
+// =====================================================================
+function showResults(cards, title) {
+  const root = document.getElementById('root');
+  const wrap = document.getElementById('results-wrap');
+  const countEl = document.getElementById('results-count');
+  const listEl = document.getElementById('results-list');
+
+  root.classList.add('has-results');
+  wrap.style.display = '';
+  countEl.textContent = title || '';
+
+  S.currentResults = cards;
+  S.focusedCard = -1;
+  S.expandedCards.clear();
+
+  listEl.innerHTML = cards.map((c, i) =>
+    '<div class="card" data-idx="' + i + '" id="card-' + i + '">' + c.html + '</div>'
+  ).join('');
+
+  // Add click handlers
+  listEl.querySelectorAll('.card').forEach(card => {
+    card.addEventListener('click', (e) => {
+      // Don't toggle if clicking inside expanded body links etc
+      if (e.target.closest('.card-body-inner a')) return;
+      const idx = parseInt(card.dataset.idx);
+      toggleCard(idx);
+    });
+  });
+
+  // Scroll to top
+  wrap.scrollTop = 0;
+}
+
+function clearResults() {
+  const root = document.getElementById('root');
+  const wrap = document.getElementById('results-wrap');
+  root.classList.remove('has-results');
+  wrap.style.display = 'none';
+  S.currentQuery = '';
+  S.currentResults = [];
+  S.focusedCard = -1;
+  S.expandedCards.clear();
+}
+
+function toggleCard(idx) {
+  const card = document.getElementById('card-' + idx);
+  if (!card) return;
+  if (S.expandedCards.has(idx)) {
+    S.expandedCards.delete(idx);
+    card.classList.remove('expanded');
+  } else {
+    S.expandedCards.add(idx);
+    card.classList.add('expanded');
+  }
+}
+
+function focusCard(idx) {
+  // Remove old focus
+  if (S.focusedCard >= 0) {
+    const old = document.getElementById('card-' + S.focusedCard);
+    if (old) old.classList.remove('focused');
+  }
+  S.focusedCard = idx;
+  if (idx >= 0) {
+    const el = document.getElementById('card-' + idx);
+    if (el) {
+      el.classList.add('focused');
+      el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }
+}
+
+// =====================================================================
+// CARD HTML BUILDERS
+// =====================================================================
+function noDataCard(title, hint) {
+  return '<div class="card-header"><span class="card-icon">\u2014</span>' +
+    '<span class="card-title" style="color:#555">' + title + '</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' +
+    (hint ? '<div style="color:#333;font-size:11px;padding-top:8px">' + hint + '</div>' : '') +
+    '</div></div>';
+}
+
+// ── Status ──
+function renderStatus() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data available', 'Waiting for snapshot...') }], 'Status'); return; }
+  const s = snap.summary || {};
+  const sc = s.status_counts || {};
+  const alerts = snap.alerts || [];
+
+  const metricGrid =
+    '<div class="metric-grid">' +
+    metricCell('Lanes', s.lanes_total || 0, '') +
+    metricCell('Done', sc.done || 0, 'ok') +
+    metricCell('Active', sc.in_progress || 0, 'info') +
+    metricCell('Blocked', sc.blocked || 0, (sc.blocked || 0) > 0 ? 'crit' : '') +
+    metricCell('Cost', fmtCost(s.total_cost_usd || 0), '') +
+    metricCell('Tokens', fmtTokens(s.total_tokens || 0), '') +
+    metricCell('Responses', s.total_responses || 0, '') +
+    metricCell('Alerts', s.alerts_count || 0, (s.alerts_count || 0) > 0 ? 'warn' : '') +
+    '</div>';
+
+  const ownersHTML = Object.entries(s.owner_counts || {}).map(([owner, count]) =>
+    '<span style="margin-right:12px">' + ownerBadge(owner) + ' <span style="color:#888;font-size:11px">' + esc(count) + ' lanes</span></span>'
+  ).join('');
+
+  const body = metricGrid +
+    '<div class="detail-section"><div class="detail-section-title">Owners</div>' +
+    '<div style="padding:6px 0">' + (ownersHTML || '<span style="color:#444">None</span>') + '</div></div>' +
+    (alerts.length > 0 ?
+      '<div class="detail-section"><div class="detail-section-title">Active Alerts (' + alerts.length + ')</div>' +
+      alerts.slice(0, 5).map(a =>
+        '<div class="detail-row"><span>' + severityBadge(a.severity) + ' <span style="color:#999;font-size:11px;margin-left:6px">' + esc(a.message) + '</span></span></div>'
+      ).join('') + '</div>' : '');
+
+  const card = '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('status') + '</span>' +
+    '<span class="card-title">Swarm Status Overview</span>' +
+    '<span class="card-stat">' + esc(s.lanes_total || 0) + ' lanes</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+
+  showResults([{ html: card }], 'Status');
+  // Auto-expand
+  setTimeout(() => toggleCard(0), 50);
+}
+
+function metricCell(label, value, cls) {
+  return '<div class="metric-cell"><div class="metric-label">' + esc(label) + '</div>' +
+    '<div class="metric-value ' + cls + '">' + esc(value) + '</div></div>';
+}
+
+// ── Blocked ──
+function renderBlocked() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Blocked'); return; }
+  const blocked = (snap.lanes || []).filter(l => l.status === 'blocked');
+  if (!blocked.length) {
+    showResults([{ html: noDataCard('No blocked lanes', 'All lanes are running smoothly') }], 'Blocked Lanes (0)');
+    return;
+  }
+  const cards = blocked.map(lane => ({ html: laneCardHTML(lane) }));
+  showResults(cards, 'Blocked Lanes (' + blocked.length + ')');
+}
+
+// ── Alerts ──
+function renderAlerts() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Alerts'); return; }
+  const alerts = snap.alerts || [];
+  if (!alerts.length) {
+    showResults([{ html: noDataCard('No active alerts', 'All systems nominal') }], 'Alerts (0)');
+    return;
+  }
+  const cards = alerts.map(a => ({ html: alertCardHTML(a) }));
+  showResults(cards, 'Active Alerts (' + alerts.length + ')');
+}
+
+// ── Cost ──
+function renderCost() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Cost'); return; }
+  const s = snap.summary || {};
+  const cs = S.costSeries || {};
+
+  // Total cost metric
+  const totalCard = buildCostOverviewCard(s, cs);
+
+  // Per-owner breakdown
+  const ownerCards = [];
+  const lanes = snap.lanes || [];
+  const byOwner = {};
+  lanes.forEach(l => {
+    const o = l.owner || 'unknown';
+    if (!byOwner[o]) byOwner[o] = { cost: 0, tokens: 0, responses: 0, lanes: 0 };
+    byOwner[o].cost += (l.metrics || {}).cost_usd_total || 0;
+    byOwner[o].tokens += (l.metrics || {}).tokens_total || 0;
+    byOwner[o].responses += (l.metrics || {}).responses_total || 0;
+    byOwner[o].lanes++;
+  });
+
+  Object.entries(byOwner).sort((a, b) => b[1].cost - a[1].cost).forEach(([owner, data]) => {
+    ownerCards.push({ html: costOwnerCardHTML(owner, data) });
+  });
+
+  // Per-provider if available
+  const providerCards = [];
+  if (cs.by_provider) {
+    Object.entries(cs.by_provider).sort((a, b) => (b[1] || 0) - (a[1] || 0)).forEach(([prov, cost]) => {
+      providerCards.push({ html: costProviderCardHTML(prov, cost) });
+    });
+  }
+
+  showResults([{ html: totalCard }, ...ownerCards, ...providerCards], 'Cost Breakdown');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+function buildCostOverviewCard(s, cs) {
+  const windows = cs.windows || {};
+  const grid = '<div class="metric-grid">' +
+    metricCell('Total', fmtCost(s.total_cost_usd || 0), '') +
+    metricCell('1h', fmtCost(windows['1h'] || 0), '') +
+    metricCell('6h', fmtCost(windows['6h'] || 0), '') +
+    metricCell('24h', fmtCost(windows['24h'] || 0), '') +
+    '</div>';
+
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('cost') + '</span>' +
+    '<span class="card-title">Cost Overview</span>' +
+    '<span class="card-stat">' + fmtCost(s.total_cost_usd || 0) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + grid + '</div></div>';
+}
+
+function costOwnerCardHTML(owner, data) {
+  const body = '<div class="metric-grid">' +
+    metricCell('Cost', fmtCost(data.cost), '') +
+    metricCell('Tokens', fmtTokens(data.tokens), '') +
+    metricCell('Responses', data.responses, '') +
+    metricCell('Lanes', data.lanes, '') +
+    '</div>';
+
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('owner') + '</span>' +
+    '<span class="card-title">' + ownerBadge(owner) + '</span>' +
+    '<span class="card-stat">' + fmtCost(data.cost) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+}
+
+function costProviderCardHTML(provider, cost) {
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('endpoint') + '</span>' +
+    '<span class="card-title" style="color:#888">Provider: ' + esc(provider) + '</span>' +
+    '<span class="card-stat">' + fmtCost(cost || 0) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' +
+    '<div class="detail-row"><span class="detail-key">30d cost</span><span class="detail-val">' + fmtCost(cost || 0) + '</span></div>' +
+    '</div></div>';
+}
+
+// ── Lanes ──
+function renderLanes() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Lanes'); return; }
+  const lanes = snap.lanes || [];
+  if (!lanes.length) {
+    showResults([{ html: noDataCard('No lanes discovered') }], 'Lanes (0)');
+    return;
+  }
+
+  // Group by status
+  const groups = { blocked: [], in_progress: [], pending: [], done: [], idle: [] };
+  lanes.forEach(l => {
+    const g = groups[l.status] || groups.idle;
+    g.push(l);
+  });
+
+  const cards = [];
+  for (const [status, group] of Object.entries(groups)) {
+    if (!group.length) continue;
+    group.forEach(lane => cards.push({ html: laneCardHTML(lane) }));
+  }
+
+  showResults(cards, 'All Lanes (' + lanes.length + ')');
+}
+
+// ── Lane detail ──
+function renderLane(arg) {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Lane'); return; }
+  if (!arg) {
+    showResults([{ html: noDataCard('Specify a lane name', 'Usage: /lane <name>') }], 'Lane');
+    return;
+  }
+  const lanes = snap.lanes || [];
+  // Fuzzy match
+  let best = null, bestScore = 0;
+  for (const l of lanes) {
+    const score = fuzzyScore(arg, l.lane_id);
+    if (score > bestScore) { bestScore = score; best = l; }
+  }
+  if (!best) {
+    showResults([{ html: noDataCard('No lane matching "' + esc(arg) + '"') }], 'Lane');
+    return;
+  }
+  showResults([{ html: laneCardHTML(best, arg) }], 'Lane: ' + esc(best.lane_id));
+  setTimeout(() => toggleCard(0), 50);
+}
+
+function laneCardHTML(lane, query) {
+  const tc = lane.task_counts || {};
+  const total = (tc.done || 0) + (tc.in_progress || 0) + (tc.blocked || 0) + (tc.pending || 0);
+  const done = tc.done || 0;
+  const pct = total > 0 ? Math.round(done / total * 100) : 0;
+  const cost = (lane.metrics || {}).cost_usd_total || 0;
+
+  const header = '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('lane') + '</span>' +
+    '<span class="card-title">' + (query ? highlightMatch(lane.lane_id, query) : esc(lane.lane_id)) + '</span>' +
+    '<span class="card-stat">' + statusBadge(lane.status) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>';
+
+  // Collapsed subtitle
+  const subtitle = '<div style="padding:0 16px 10px;font-size:11px;color:#555;display:flex;gap:12px;flex-wrap:wrap">' +
+    ownerBadge(lane.owner) +
+    '<span>' + done + '/' + total + ' tasks</span>' +
+    '<span>' + fmtCost(cost) + '</span>' +
+    (lane.heartbeat && lane.heartbeat.age_sec >= 0 ? '<span>' + fmtTime(lane.heartbeat.timestamp) + '</span>' : '') +
+    '</div>';
+
+  // Expanded body
+  const grid = '<div class="metric-grid">' +
+    metricCell('Done', tc.done || 0, 'ok') +
+    metricCell('Active', tc.in_progress || 0, 'info') +
+    metricCell('Blocked', tc.blocked || 0, (tc.blocked || 0) > 0 ? 'crit' : '') +
+    metricCell('Pending', tc.pending || 0, (tc.pending || 0) > 0 ? 'warn' : '') +
+    '</div>';
+
+  const progressBar = '<div class="progress"><div class="progress-fill ' +
+    (lane.status === 'blocked' ? 'crit' : lane.status === 'done' ? 'ok' : 'info') +
+    '" style="width:' + pct + '%"></div></div>';
+
+  const metricsSection = '<div class="detail-section"><div class="detail-section-title">Metrics</div>' +
+    '<div class="detail-row"><span class="detail-key">Cost</span><span class="detail-val">' + fmtCost(cost) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Tokens</span><span class="detail-val">' + fmtTokens((lane.metrics || {}).tokens_total || 0) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Responses</span><span class="detail-val">' + ((lane.metrics || {}).responses_total || 0) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Pass Rate</span><span class="detail-val">' + fmtPct((lane.metrics || {}).first_time_pass_rate || 0) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Avg Latency</span><span class="detail-val">' + ((lane.metrics || {}).latency_sec_avg || 0).toFixed(1) + 's</span></div>' +
+    '</div>';
+
+  const hb = lane.heartbeat || {};
+  const heartbeatSection = '<div class="detail-section"><div class="detail-section-title">Heartbeat</div>' +
+    '<div class="detail-row"><span class="detail-key">Cycle</span><span class="detail-val">' + esc(hb.cycle || 0) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Phase</span><span class="detail-val">' + esc(hb.phase || '-') + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Age</span><span class="detail-val">' + (hb.age_sec >= 0 ? hb.age_sec + 's' : 'unknown') + '</span></div>' +
+    (hb.message ? '<div class="detail-row"><span class="detail-key">Message</span><span class="detail-val" style="max-width:70%">' + esc(hb.message) + '</span></div>' : '') +
+    '</div>';
+
+  const tasks = lane.tasks || [];
+  const tasksSection = tasks.length > 0 ?
+    '<div class="detail-section"><div class="detail-section-title">Tasks (' + tasks.length + ')</div>' +
+    tasks.map(t =>
+      '<div class="task-item task-' + esc(t.status) + '">' +
+      '<span class="task-id">' + esc(t.task_id) + '</span>' +
+      '<span class="task-summary">' + esc(t.last_summary || '-') + '</span>' +
+      '<span class="task-meta">' + statusBadge(t.status) + '</span>' +
+      '</div>'
+    ).join('') + '</div>' : '';
+
+  const cfg = lane.config || {};
+  const configSection = '<div class="detail-section"><div class="detail-section-title">Config</div>' +
+    '<div class="detail-row"><span class="detail-key">Profile</span><span class="detail-val">' + esc(cfg.execution_profile || '-') + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Continuous</span><span class="detail-val">' + (cfg.continuous ? 'yes' : 'no') + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Max Cycles</span><span class="detail-val">' + (cfg.max_cycles || '-') + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Started</span><span class="detail-val">' + fmtTime(cfg.started_at) + '</span></div>' +
+    '</div>';
+
+  const body = grid + progressBar + metricsSection + heartbeatSection + tasksSection + configSection;
+
+  return header + subtitle +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+}
+
+// ── Alert card ──
+function alertCardHTML(alert, query) {
+  const header = '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('alert') + '</span>' +
+    '<span class="card-title">' + (query ? highlightMatch(alert.message, query) : esc(alert.message)) + '</span>' +
+    '<span class="card-stat">' + severityBadge(alert.severity) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>';
+
+  const body = '<div class="detail-row"><span class="detail-key">Severity</span><span class="detail-val">' + severityBadge(alert.severity) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Type</span><span class="detail-val">' + esc(alert.type) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Message</span><span class="detail-val" style="max-width:70%">' + esc(alert.message) + '</span></div>' +
+    (alert.lane_id ? '<div class="detail-row"><span class="detail-key">Lane</span><span class="detail-val" style="color:#3b82f6;cursor:pointer" onclick="event.stopPropagation();document.getElementById(\'cmd-input\').value=\'/lane ' + esc(alert.lane_id) + '\';executeQuery(\'/lane ' + esc(alert.lane_id) + '\')">' + esc(alert.lane_id) + '</span></div>' : '');
+
+  return header +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+}
+
+// ── Event card ──
+function eventCardHTML(evt, query) {
+  const msg = evt.message || evt.event || '';
+  const type = evt.type || evt.event || '';
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('event') + '</span>' +
+    '<span class="card-title">' + (query ? highlightMatch(msg, query) : esc(msg)) + '</span>' +
+    '<span class="card-stat" style="font-size:10px;color:#555">' + fmtTime(evt.timestamp) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' +
+    '<div class="detail-row"><span class="detail-key">Type</span><span class="detail-val"><span class="badge badge-info">' + esc(type) + '</span></span></div>' +
+    '<div class="detail-row"><span class="detail-key">Lane</span><span class="detail-val">' + esc(evt.lane_id || '-') + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Time</span><span class="detail-val">' + esc(evt.timestamp || '') + '</span></div>' +
+    (evt.task_id ? '<div class="detail-row"><span class="detail-key">Task</span><span class="detail-val">' + esc(evt.task_id) + '</span></div>' : '') +
+    '</div></div>';
+}
+
+// ── Commit card ──
+function commitCardHTML(commit, query) {
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('commit') + '</span>' +
+    '<span class="card-title">' + (query ? highlightMatch(commit.message, query) : esc(commit.message)) + '</span>' +
+    '<span class="card-stat" style="font-size:10px;color:#555">' + esc(commit.relative_time || '') + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' +
+    '<div class="detail-row"><span class="detail-key">Hash</span><span class="detail-val" style="color:#3b82f6">' + esc(commit.short_hash) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Author</span><span class="detail-val">' + ownerBadge(commit.author) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Message</span><span class="detail-val" style="max-width:70%">' + esc(commit.message) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Time</span><span class="detail-val">' + esc(commit.relative_time || '') + '</span></div>' +
+    '</div></div>';
+}
+
+// ── Task search result ──
+function taskSearchCardHTML(task, query) {
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('task') + '</span>' +
+    '<span class="card-title"><span style="color:#3b82f6;font-weight:600">' + esc(task.task_id) + '</span> <span style="color:#666;font-size:11px">in ' + esc(task.lane_id) + '</span></span>' +
+    '<span class="card-stat">' + statusBadge(task.status) + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' +
+    '<div class="detail-row"><span class="detail-key">Summary</span><span class="detail-val" style="max-width:70%">' + (query ? highlightMatch(task.last_summary, query) : esc(task.last_summary || '-')) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Lane</span><span class="detail-val" style="color:#3b82f6;cursor:pointer" onclick="event.stopPropagation();document.getElementById(\'cmd-input\').value=\'/lane ' + esc(task.lane_id) + '\';executeQuery(\'/lane ' + esc(task.lane_id) + '\')">' + esc(task.lane_id) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Owner</span><span class="detail-val">' + ownerBadge(task.owner) + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Attempts</span><span class="detail-val">' + (task.attempts || 0) + '</span></div>' +
+    (task.last_error ? '<div class="detail-row"><span class="detail-key">Error</span><span class="detail-val" style="color:#ef4444;max-width:70%">' + esc(task.last_error) + '</span></div>' : '') +
+    '</div></div>';
+}
+
+// ── Endpoint card ──
+function endpointCardHTML(ep, query) {
+  const status = ep.status || 'unknown';
+  const isUp = status === 'ok' || status === 'up' || status === 'available';
+  return '<div class="card-header">' +
+    '<span class="card-icon"><span class="conn-dot ' + (isUp ? 'up' : status === 'unknown' ? 'unknown' : 'down') + '" style="display:inline-block"></span></span>' +
+    '<span class="card-title">' + (query ? highlightMatch(ep.name, query) : esc(ep.name)) + '</span>' +
+    '<span class="card-stat">' + (isUp ? '<span class="badge badge-success">UP</span>' : '<span class="badge badge-critical">DOWN</span>') + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' +
+    '<div class="detail-row"><span class="detail-key">Status</span><span class="detail-val">' + esc(status) + '</span></div>' +
+    (ep.latency_ms != null ? '<div class="detail-row"><span class="detail-key">Latency</span><span class="detail-val">' + ep.latency_ms + 'ms</span></div>' : '') +
+    (ep.model ? '<div class="detail-row"><span class="detail-key">Model</span><span class="detail-val">' + esc(ep.model) + '</span></div>' : '') +
+    '</div></div>';
+}
+
+// ── Generic search result ──
+function genericCardHTML(result) {
+  return '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon(result.type) + '</span>' +
+    '<span class="card-title">' + esc(result.matchedField) + ': ' + esc(result.fields?.find(f => f.key === result.matchedField)?.val || '') + '</span>' +
+    '<span class="card-stat"><span class="badge badge-muted">' + esc(result.type) + '</span></span></div>';
+}
+
+// ── Health ──
+function renderHealth() {
+  const snap = S.snapshot;
+  const report = S.report;
+  if (!snap && !report) { showResults([{ html: noDataCard('No data') }], 'Health'); return; }
+
+  const cards = [];
+
+  // From snapshot health
+  const health = snap?.health?.health || {};
+  const criteria = health.criteria || [];
+
+  if (criteria.length > 0) {
+    const passCount = criteria.filter(c => c.pass || c.status === 'pass').length;
+    const body = criteria.map(c => {
+      const pass = c.pass || c.status === 'pass';
+      const warn = c.status === 'warn' || c.status === 'warning';
+      return '<div class="health-row">' +
+        '<span class="health-indicator ' + (pass ? 'pass' : warn ? 'warn' : 'fail') + '"></span>' +
+        '<span class="health-name">' + esc(c.name || c.criterion || c.label || 'Unknown') + '</span>' +
+        '<span class="health-status">' + (pass ? '<span class="badge badge-success">PASS</span>' : warn ? '<span class="badge badge-warning">WARN</span>' : '<span class="badge badge-critical">FAIL</span>') + '</span>' +
+        '</div>';
+    }).join('');
+
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('health') + '</span>' +
+      '<span class="card-title">Health Criteria</span>' +
+      '<span class="card-stat">' + passCount + '/' + criteria.length + ' pass</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  // From report if available
+  const cycleReport = report?.cycle_report || {};
+  const healthChecks = cycleReport.health_checks || cycleReport.checks || [];
+  if (healthChecks.length > 0 && criteria.length === 0) {
+    const passCount = healthChecks.filter(c => c.pass || c.ok).length;
+    const body = healthChecks.map(c => {
+      const pass = c.pass || c.ok;
+      return '<div class="health-row">' +
+        '<span class="health-indicator ' + (pass ? 'pass' : 'fail') + '"></span>' +
+        '<span class="health-name">' + esc(c.name || c.check || 'Unknown') + '</span>' +
+        '<span class="health-status">' + (pass ? '<span class="badge badge-success">PASS</span>' : '<span class="badge badge-critical">FAIL</span>') + '</span>' +
+        '</div>';
+    }).join('');
+
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('health') + '</span>' +
+      '<span class="card-title">Health Checks (Report)</span>' +
+      '<span class="card-stat">' + passCount + '/' + healthChecks.length + ' pass</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  // Collaboration health
+  const collab = snap?.health?.collaboration || {};
+  if (Object.keys(collab).length > 0) {
+    const body = Object.entries(collab).map(([key, val]) =>
+      '<div class="detail-row"><span class="detail-key">' + esc(key) + '</span><span class="detail-val">' + esc(typeof val === 'object' ? JSON.stringify(val) : val) + '</span></div>'
+    ).join('');
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('health') + '</span>' +
+      '<span class="card-title">Collaboration Health</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  if (!cards.length) {
+    cards.push({ html: noDataCard('No health data available') });
+  }
+
+  showResults(cards, 'Health');
+  if (cards.length > 0) setTimeout(() => toggleCard(0), 50);
+}
+
+// ── Git ──
+function renderGit() {
+  const snap = S.snapshot;
+  if (!snap || !snap.git) { showResults([{ html: noDataCard('No git data') }], 'Git'); return; }
+  const git = snap.git;
+  const cards = [];
+
+  // Branch info
+  const branchBody = '<div class="detail-row"><span class="detail-key">Current Branch</span><span class="detail-val" style="color:#3b82f6">' + esc(git.current_branch || '-') + '</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Total Branches</span><span class="detail-val">' + (git.branch_count || 0) + '</span></div>';
+
+  cards.push({ html:
+    '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('commit') + '</span>' +
+    '<span class="card-title">Git State</span>' +
+    '<span class="card-stat" style="color:#3b82f6;font-size:11px">' + esc(git.current_branch || '') + '</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + branchBody + '</div></div>'
+  });
+
+  // Recent commits
+  const commits = git.recent_commits || [];
+  if (commits.length > 0) {
+    const body = commits.map(c =>
+      '<div class="commit-row">' +
+      '<span class="commit-hash">' + esc(c.short_hash) + '</span>' +
+      '<span class="commit-msg">' + esc(c.message) + '</span>' +
+      '<span class="commit-meta">' + ownerBadge(c.author) + ' ' + esc(c.relative_time || '') + '</span>' +
+      '</div>'
+    ).join('');
+
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('event') + '</span>' +
+      '<span class="card-title">Recent Commits</span>' +
+      '<span class="card-stat">' + commits.length + '</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  showResults(cards, 'Git');
+  setTimeout(() => toggleCard(0), 50);
+  if (cards.length > 1) setTimeout(() => toggleCard(1), 100);
+}
+
+// ── Events ──
+function renderEvents() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Events'); return; }
+  const events = snap.events || [];
+  if (!events.length) {
+    showResults([{ html: noDataCard('No recent events') }], 'Events (0)');
+    return;
+  }
+
+  // Group into a single expandable card with all events
+  const body = events.slice(0, 50).map(evt => {
+    const msg = evt.message || evt.event || '';
+    const type = evt.type || evt.event || '';
+    return '<div class="event-row">' +
+      '<span class="event-time">' + fmtTimeShort(evt.timestamp) + '</span>' +
+      '<span class="badge badge-info" style="flex-shrink:0;margin-right:6px">' + esc(type) + '</span>' +
+      '<span class="event-body">' + esc(msg) + '</span>' +
+      '<span class="event-lane">' + esc(evt.lane_id || '') + '</span>' +
+      '</div>';
+  }).join('');
+
+  const card = '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('event') + '</span>' +
+    '<span class="card-title">Event Stream</span>' +
+    '<span class="card-stat">' + events.length + ' events</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+
+  showResults([{ html: card }], 'Events (' + events.length + ')');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+// ── Owners ──
+function renderOwners() {
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data') }], 'Owners'); return; }
+  const lanes = snap.lanes || [];
+  const byOwner = {};
+  lanes.forEach(l => {
+    const o = l.owner || 'unknown';
+    if (!byOwner[o]) byOwner[o] = { lanes: [], cost: 0, tokens: 0, responses: 0, done: 0, blocked: 0, active: 0 };
+    byOwner[o].lanes.push(l);
+    byOwner[o].cost += (l.metrics || {}).cost_usd_total || 0;
+    byOwner[o].tokens += (l.metrics || {}).tokens_total || 0;
+    byOwner[o].responses += (l.metrics || {}).responses_total || 0;
+    const tc = l.task_counts || {};
+    byOwner[o].done += tc.done || 0;
+    byOwner[o].blocked += tc.blocked || 0;
+    byOwner[o].active += tc.in_progress || 0;
+  });
+
+  const cards = Object.entries(byOwner).sort((a, b) => b[1].lanes.length - a[1].lanes.length).map(([owner, data]) => {
+    const grid = '<div class="metric-grid">' +
+      metricCell('Lanes', data.lanes.length, '') +
+      metricCell('Done', data.done, 'ok') +
+      metricCell('Active', data.active, 'info') +
+      metricCell('Blocked', data.blocked, data.blocked > 0 ? 'crit' : '') +
+      metricCell('Cost', fmtCost(data.cost), '') +
+      metricCell('Tokens', fmtTokens(data.tokens), '') +
+      metricCell('Responses', data.responses, '') +
+      metricCell('Pass Rate', '-', '') +
+      '</div>';
+
+    const lanesList = '<div class="detail-section"><div class="detail-section-title">Lanes (' + data.lanes.length + ')</div>' +
+      data.lanes.map(l =>
+        '<div class="detail-row" style="cursor:pointer" onclick="event.stopPropagation();document.getElementById(\'cmd-input\').value=\'/lane ' + esc(l.lane_id) + '\';executeQuery(\'/lane ' + esc(l.lane_id) + '\')">' +
+        '<span class="detail-key" style="color:#3b82f6">' + esc(l.lane_id) + '</span>' +
+        '<span class="detail-val">' + statusBadge(l.status) + '</span></div>'
+      ).join('') + '</div>';
+
+    return { html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('owner') + '</span>' +
+      '<span class="card-title">' + ownerBadge(owner) + '</span>' +
+      '<span class="card-stat">' + data.lanes.length + ' lanes</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + grid + lanesList + '</div></div>'
+    };
+  });
+
+  showResults(cards, 'Owners (' + Object.keys(byOwner).length + ')');
+}
+
+// ── Connectivity ──
+function renderConnectivity() {
+  const snap = S.snapshot;
+  if (!snap || !snap.connectivity) { showResults([{ html: noDataCard('No connectivity data') }], 'Connectivity'); return; }
+  const conn = snap.connectivity;
+  const endpoints = [];
+
+  // Handle both flat object and nested structures
+  if (conn.endpoints && Array.isArray(conn.endpoints)) {
+    conn.endpoints.forEach(ep => endpoints.push(ep));
+  } else {
+    Object.entries(conn).forEach(([name, info]) => {
+      if (typeof info === 'object' && info !== null) {
+        endpoints.push({ name, ...info });
+      }
+    });
+  }
+
+  if (!endpoints.length) {
+    showResults([{ html: noDataCard('No endpoints found') }], 'Connectivity');
+    return;
+  }
+
+  const body = endpoints.map(ep => {
+    const status = ep.status || ep.state || 'unknown';
+    const isUp = ['ok', 'up', 'available', 'healthy'].includes(status.toLowerCase());
+    return '<div class="conn-row">' +
+      '<span class="conn-dot ' + (isUp ? 'up' : status === 'unknown' ? 'unknown' : 'down') + '"></span>' +
+      '<span class="conn-name">' + esc(ep.name || ep.endpoint || ep.model || 'Unknown') + '</span>' +
+      (ep.latency_ms != null ? '<span class="conn-latency">' + ep.latency_ms + 'ms</span>' : '') +
+      '<span style="margin-left:8px">' + (isUp ? '<span class="badge badge-success">UP</span>' : '<span class="badge badge-critical">DOWN</span>') + '</span>' +
+      '</div>';
+  }).join('');
+
+  const upCount = endpoints.filter(ep => {
+    const s = (ep.status || ep.state || '').toLowerCase();
+    return ['ok', 'up', 'available', 'healthy'].includes(s);
+  }).length;
+
+  const card = '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('endpoint') + '</span>' +
+    '<span class="card-title">Model Endpoints</span>' +
+    '<span class="card-stat">' + upCount + '/' + endpoints.length + ' up</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+
+  showResults([{ html: card }], 'Connectivity');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+// ── Privileges ──
+function renderPrivileges() {
+  const priv = S.privileges;
+  if (!priv) { showResults([{ html: noDataCard('No privilege data', 'Waiting for /api/v2/privileges...') }], 'Privileges'); return; }
+
+  const cards = [];
+  const current = priv.current || {};
+
+  if (Object.keys(current).length > 0) {
+    const body = Object.entries(current).map(([key, val]) =>
+      '<div class="priv-row">' +
+      '<span class="priv-key">' + esc(key) + '</span>' +
+      '<span class="priv-val">' + esc(typeof val === 'object' ? JSON.stringify(val) : val) + '</span>' +
+      '</div>'
+    ).join('');
+
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('privilege') + '</span>' +
+      '<span class="card-title">Current Privileges</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  const escalations = priv.recent_escalations || [];
+  if (escalations.length > 0) {
+    const body = escalations.map(e =>
+      '<div class="event-row">' +
+      '<span class="event-time">' + fmtTime(e.timestamp) + '</span>' +
+      '<span class="event-body">' + esc(e.reason || e.action || e.type || JSON.stringify(e)) + '</span>' +
+      '</div>'
+    ).join('');
+
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('event') + '</span>' +
+      '<span class="card-title">Recent Escalations</span>' +
+      '<span class="card-stat">' + escalations.length + '</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  if (!cards.length) cards.push({ html: noDataCard('No privilege data available') });
+  showResults(cards, 'Privileges');
+  if (cards.length > 0) setTimeout(() => toggleCard(0), 50);
+}
+
+// ── Policies ──
+function renderPolicies() {
+  const pol = S.policies;
+  if (!pol || !pol.policies) { showResults([{ html: noDataCard('No policy data', 'Waiting for /api/v2/policies...') }], 'Policies'); return; }
+  const policies = pol.policies;
+
+  if (!Object.keys(policies).length) {
+    showResults([{ html: noDataCard('No policies found') }], 'Policies');
+    return;
+  }
+
+  const cards = Object.entries(policies).map(([name, data]) => {
+    const isHealthy = data.healthy || data.compliant || data.ok || data.status === 'pass';
+    const body = Object.entries(data).filter(([k]) => !['timestamp'].includes(k)).map(([key, val]) =>
+      '<div class="detail-row"><span class="detail-key">' + esc(key) + '</span><span class="detail-val" style="max-width:70%">' + esc(typeof val === 'object' ? JSON.stringify(val) : val) + '</span></div>'
+    ).join('');
+
+    return { html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('policy') + '</span>' +
+      '<span class="card-title" style="text-transform:capitalize">' + esc(name.replace(/_/g, ' ')) + '</span>' +
+      '<span class="card-stat">' + (isHealthy ? '<span class="badge badge-success">COMPLIANT</span>' : '<span class="badge badge-warning">CHECK</span>') + '</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    };
+  });
+
+  showResults(cards, 'Policies (' + Object.keys(policies).length + ')');
+}
+
+// ── Backlog ──
+function renderBacklog() {
+  const bl = S.backlog;
+  if (!bl) { showResults([{ html: noDataCard('No backlog data', 'Waiting for /api/v2/task-backlog...') }], 'Backlog'); return; }
+
+  const cards = [];
+
+  // Overview
+  const grid = '<div class="metric-grid">' +
+    metricCell('Total', bl.total || 0, '') +
+    metricCell('Owners', Object.keys(bl.by_owner || {}).length, '') +
+    '</div>';
+
+  const ownerBreakdown = Object.entries(bl.by_owner || {}).map(([owner, count]) =>
+    '<div class="detail-row"><span class="detail-key">' + ownerBadge(owner) + '</span><span class="detail-val">' + count + ' tasks</span></div>'
+  ).join('');
+
+  const prioBreakdown = Object.entries(bl.by_priority || {}).map(([prio, count]) =>
+    '<div class="detail-row"><span class="detail-key">Priority ' + esc(prio) + '</span><span class="detail-val">' + count + '</span></div>'
+  ).join('');
+
+  cards.push({ html:
+    '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('backlog') + '</span>' +
+    '<span class="card-title">Backlog Overview</span>' +
+    '<span class="card-stat">' + (bl.total || 0) + ' tasks</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + grid +
+    (ownerBreakdown ? '<div class="detail-section"><div class="detail-section-title">By Owner</div>' + ownerBreakdown + '</div>' : '') +
+    (prioBreakdown ? '<div class="detail-section"><div class="detail-section-title">By Priority</div>' + prioBreakdown + '</div>' : '') +
+    '</div></div>'
+  });
+
+  // Individual tasks
+  const tasks = bl.tasks || [];
+  if (tasks.length > 0) {
+    const body = tasks.slice(0, 30).map(t => {
+      const id = t.id || t.task_id || '?';
+      const desc = t.description || t.summary || t.title || '';
+      const owner = t.owner || '?';
+      const prio = t.priority || '?';
+      return '<div class="backlog-task">' +
+        '<span class="bt-id">' + esc(id) + '</span>' +
+        (desc ? '<div class="bt-desc">' + esc(desc) + '</div>' : '') +
+        '<div class="bt-meta">' + ownerBadge(owner) + ' <span>priority: ' + esc(prio) + '</span></div>' +
+        '</div>';
+    }).join('');
+
+    cards.push({ html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('task') + '</span>' +
+      '<span class="card-title">Tasks</span>' +
+      '<span class="card-stat">' + tasks.length + '</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>'
+    });
+  }
+
+  showResults(cards, 'Backlog');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+// ── Metrics ──
+function renderMetrics() {
+  const snap = S.snapshot;
+  if (!snap || !snap.metrics) { showResults([{ html: noDataCard('No metrics data') }], 'Metrics'); return; }
+  const m = snap.metrics;
+  const g = m.global || {};
+
+  const cards = [];
+
+  const grid = '<div class="metric-grid">' +
+    metricCell('Responses', g.responses_total || 0, '') +
+    metricCell('Cost', fmtCost(g.cost_usd_total || 0), '') +
+    metricCell('Tokens', fmtTokens(g.tokens_total || 0), '') +
+    metricCell('FTP Rate', fmtPct(g.first_time_pass_rate || 0), (g.first_time_pass_rate || 0) >= 0.8 ? 'ok' : (g.first_time_pass_rate || 0) >= 0.5 ? 'warn' : 'crit') +
+    '</div>';
+
+  // By-owner metrics from global
+  const byOwner = g.by_owner || {};
+  let ownerSection = '';
+  if (Object.keys(byOwner).length > 0) {
+    ownerSection = '<div class="detail-section"><div class="detail-section-title">By Owner</div>' +
+      Object.entries(byOwner).map(([owner, data]) =>
+        '<div class="detail-row"><span class="detail-key">' + ownerBadge(owner) + '</span><span class="detail-val">' +
+        (data.responses_total || 0) + ' resp, ' + fmtCost(data.cost_usd_total || 0) +
+        (data.latency_sec_avg ? ', ' + data.latency_sec_avg.toFixed(1) + 's avg' : '') +
+        '</span></div>'
+      ).join('') + '</div>';
+  }
+
+  // Per-lane metrics
+  const perLane = m.per_lane || {};
+  let laneSection = '';
+  if (Object.keys(perLane).length > 0) {
+    laneSection = '<div class="detail-section"><div class="detail-section-title">By Lane (top 10)</div>' +
+      Object.entries(perLane)
+        .sort((a, b) => (b[1].cost_usd_total || 0) - (a[1].cost_usd_total || 0))
+        .slice(0, 10)
+        .map(([lane, data]) =>
+          '<div class="detail-row"><span class="detail-key" style="color:#3b82f6;cursor:pointer" onclick="event.stopPropagation();document.getElementById(\'cmd-input\').value=\'/lane ' + esc(lane) + '\';executeQuery(\'/lane ' + esc(lane) + '\')">' + esc(lane) + '</span>' +
+          '<span class="detail-val">' + (data.responses_total || 0) + ' resp, ' + fmtCost(data.cost_usd_total || 0) + ', FTP ' + fmtPct(data.first_time_pass_rate || 0) + '</span></div>'
+        ).join('') + '</div>';
+  }
+
+  cards.push({ html:
+    '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('metric') + '</span>' +
+    '<span class="card-title">Response Metrics</span>' +
+    '<span class="card-stat">' + (g.responses_total || 0) + ' total</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + grid + ownerSection + laneSection + '</div></div>'
+  });
+
+  showResults(cards, 'Metrics');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+// ── Responses ──
+function renderResponses() {
+  const rs = S.responseStream;
+  if (!rs || !rs.length) { showResults([{ html: noDataCard('No response data', 'Waiting for /api/v2/response-stream...') }], 'Responses'); return; }
+
+  const cards = rs.slice(0, 30).map(r => {
+    const pass = r.accepted || r.pass || r.first_time_pass;
+    const model = r.model || r.owner || '?';
+    const lane = r.lane_id || '?';
+    const latency = r.latency_sec || r.duration_sec || 0;
+    const cost = r.cost_usd || 0;
+    const tokens = r.tokens_total || r.tokens || 0;
+
+    return { html:
+      '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('response') + '</span>' +
+      '<span class="card-title"><span style="color:#888;font-size:11px">' + esc(lane) + '</span></span>' +
+      '<span class="card-stat" style="display:flex;gap:6px;align-items:center">' +
+      (pass ? '<span class="badge badge-success">PASS</span>' : '<span class="badge badge-critical">FAIL</span>') +
+      '<span style="font-size:10px;color:#555">' + fmtCost(cost) + '</span>' +
+      '</span>' +
+      '<span class="card-chevron">\u25b8</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' +
+      '<div class="detail-row"><span class="detail-key">Model</span><span class="detail-val">' + esc(model) + '</span></div>' +
+      '<div class="detail-row"><span class="detail-key">Lane</span><span class="detail-val">' + esc(lane) + '</span></div>' +
+      '<div class="detail-row"><span class="detail-key">Latency</span><span class="detail-val">' + latency.toFixed(1) + 's</span></div>' +
+      '<div class="detail-row"><span class="detail-key">Cost</span><span class="detail-val">' + fmtCost(cost) + '</span></div>' +
+      '<div class="detail-row"><span class="detail-key">Tokens</span><span class="detail-val">' + fmtTokens(tokens) + '</span></div>' +
+      '<div class="detail-row"><span class="detail-key">Time</span><span class="detail-val">' + fmtTime(r.timestamp) + '</span></div>' +
+      '</div></div>'
+    };
+  });
+
+  showResults(cards, 'Recent Responses (' + rs.length + ')');
+}
+
+// ── Help ──
+function renderHelp() {
+  const body = '<div class="help-grid">' +
+    COMMANDS.map(c =>
+      '<div class="help-item">' +
+      '<span class="help-cmd">' + esc(c.cmd) +
+      (c.aliases.length ? ' <span style="color:#444">' + c.aliases.map(a => esc(a)).join(' ') + '</span>' : '') +
+      '</span>' +
+      '<span class="help-desc">' + esc(c.desc) + '</span>' +
+      '</div>'
+    ).join('') +
+    '</div>' +
+    '<div class="detail-section" style="margin-top:16px"><div class="detail-section-title">Keyboard Shortcuts</div>' +
+    '<div class="detail-row"><span class="detail-key">Up/Down</span><span class="detail-val">Navigate results</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Enter</span><span class="detail-val">Expand/collapse card</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Escape</span><span class="detail-val">Clear results / input</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Tab</span><span class="detail-val">Accept autocomplete</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Cmd/Ctrl+K</span><span class="detail-val">Focus command bar</span></div>' +
+    '<div class="detail-row"><span class="detail-key">Up arrow (empty input)</span><span class="detail-val">Command history</span></div>' +
+    '</div>' +
+    '<div class="detail-section"><div class="detail-section-title">Free Text Search</div>' +
+    '<div style="padding:6px 0;font-size:12px;color:#777">Type any text without <span style="color:#3b82f6">/</span> to fuzzy search across lane IDs, task IDs, summaries, alert messages, events, commits, and endpoint names.</div>' +
+    '</div>';
+
+  const card = '<div class="card-header">' +
+    '<span class="card-icon">' + cardIcon('help') + '</span>' +
+    '<span class="card-title">Available Commands</span>' +
+    '<span class="card-stat">' + COMMANDS.length + ' commands</span>' +
+    '<span class="card-chevron">\u25b8</span></div>' +
+    '<div class="card-body"><div class="card-body-inner">' + body + '</div></div>';
+
+  showResults([{ html: card }], 'Help');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+// =====================================================================
+// ACTION COMMAND HANDLERS
+// =====================================================================
+async function handleUnblock(arg) {
+  if (arg) {
+    // Direct unblock with task_id argument
+    executeAction('task.clear-error', { task_id: arg });
+    return;
+  }
+  // No arg: show blocked tasks for selection
+  const snap = S.snapshot;
+  if (!snap) { showResults([{ html: noDataCard('No data available') }], 'Unblock'); return; }
+  const blockedTasks = [];
+  (snap.lanes || []).forEach(lane => {
+    (lane.tasks || []).forEach(task => {
+      if (task.status === 'blocked') {
+        blockedTasks.push({ ...task, lane_id: lane.lane_id });
+      }
+    });
+  });
+  if (!blockedTasks.length) {
+    showResults([{ html: noDataCard('No blocked tasks found', 'All tasks are running smoothly') }], 'Unblock');
+    return;
+  }
+  const cards = blockedTasks.map(t => ({
+    html: '<div class="card-header">' +
+      '<span class="card-icon">' + cardIcon('task') + '</span>' +
+      '<span class="card-title"><span style="color:#3b82f6;font-weight:600">' + esc(t.task_id) + '</span> <span style="color:#666;font-size:11px">in ' + esc(t.lane_id) + '</span></span>' +
+      '<span class="card-stat">' + statusBadge(t.status) + '</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' +
+      (t.last_error ? '<div style="color:#ef4444;font-size:11px;margin-bottom:8px">' + esc(t.last_error) + '</div>' : '') +
+      '<button class="action-confirm-btn confirm-yes" onclick="event.stopPropagation();executeAction(\'task.clear-error\',{task_id:\'' + esc(t.task_id) + '\'})">Unblock this task</button>' +
+      '</div></div>'
+  }));
+  showResults(cards, 'Blocked Tasks (' + blockedTasks.length + ') \u2014 click to unblock');
+}
+
+function handleReprioritize(arg) {
+  const parts = arg.split(/\s+/);
+  if (parts.length < 2 || !parts[0] || !parts[1]) {
+    showResults([{ html: noDataCard('Usage: /reprioritize <task_id> <priority>', 'Example: /reprioritize task-beta high') }], 'Reprioritize');
+    return;
+  }
+  const taskId = parts[0];
+  const priority = parts[1];
+  executeAction('task.reprioritize', { task_id: taskId, priority: priority });
+}
+
+function handleGrant(arg) {
+  // Show a form-like card for breakglass grant
+  const card = {
+    html: '<div class="card-header">' +
+      '<span class="card-icon">&#9888;</span>' +
+      '<span class="card-title">Issue Breakglass Grant</span>' +
+      '<span class="badge badge-warning">BREAKGLASS</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' +
+      '<div style="margin-bottom:10px">' +
+      '<label style="font-size:10px;color:#555;text-transform:uppercase;letter-spacing:0.1em;display:block;margin-bottom:4px">Reason</label>' +
+      '<input id="grant-reason" type="text" style="width:100%;background:#0e0e0e;border:1px solid #252525;border-radius:4px;padding:8px 10px;font-family:inherit;font-size:12px;color:#e0e0e0;outline:none" placeholder="Reason for breakglass access">' +
+      '</div>' +
+      '<div style="margin-bottom:10px">' +
+      '<label style="font-size:10px;color:#555;text-transform:uppercase;letter-spacing:0.1em;display:block;margin-bottom:4px">Scope</label>' +
+      '<input id="grant-scope" type="text" style="width:100%;background:#0e0e0e;border:1px solid #252525;border-radius:4px;padding:8px 10px;font-family:inherit;font-size:12px;color:#e0e0e0;outline:none" placeholder="e.g. full, read-only, lane:my-lane">' +
+      '</div>' +
+      '<div style="margin-bottom:12px">' +
+      '<label style="font-size:10px;color:#555;text-transform:uppercase;letter-spacing:0.1em;display:block;margin-bottom:4px">TTL (minutes)</label>' +
+      '<input id="grant-ttl" type="number" value="30" style="width:120px;background:#0e0e0e;border:1px solid #252525;border-radius:4px;padding:8px 10px;font-family:inherit;font-size:12px;color:#e0e0e0;outline:none">' +
+      '</div>' +
+      '<button class="action-confirm-btn confirm-yes" onclick="event.stopPropagation();submitGrant()">Issue Grant</button>' +
+      '<button class="action-confirm-btn confirm-no" style="margin-left:8px" onclick="event.stopPropagation();clearResults()">Cancel</button>' +
+      '</div></div>'
+  };
+  showResults([card], 'Breakglass Grant');
+  setTimeout(() => toggleCard(0), 50);
+}
+
+async function submitGrant() {
+  const reason = document.getElementById('grant-reason').value;
+  const scope = document.getElementById('grant-scope').value;
+  const ttl = parseInt(document.getElementById('grant-ttl').value) || 30;
+  if (!reason) {
+    showResults([{ html: noDataCard('Reason is required', 'Please provide a reason for the breakglass grant') }], 'Grant Failed');
+    return;
+  }
+  executeAction('breakglass.grant', { reason, scope, ttl_minutes: ttl });
+}
+
+function handleRevoke(arg) {
+  if (!arg) {
+    showResults([{ html: noDataCard('Usage: /revoke <grant_id>', 'Example: /revoke bg-abc123') }], 'Revoke');
+    return;
+  }
+  executeAction('breakglass.revoke', { grant_id: arg });
+}
+
+async function renderAudit() {
+  try {
+    const data = await fetchJSON('/api/v2/actions/audit');
+    const entries = data.entries || data.audit || data || [];
+    if (!Array.isArray(entries) || !entries.length) {
+      showResults([{ html: noDataCard('No audit entries found') }], 'Audit Trail');
+      return;
+    }
+    const cards = entries.slice(0, 50).map(entry => ({
+      html: '<div class="card-header">' +
+        '<span class="card-icon">' + cardIcon('event') + '</span>' +
+        '<span class="card-title">' + esc(entry.action || entry.action_id || 'unknown') + '</span>' +
+        '<span class="card-stat" style="font-size:10px;color:#555">' + fmtTime(entry.timestamp) + '</span>' +
+        '<span class="card-chevron">\u25b8</span></div>' +
+        '<div class="card-body"><div class="card-body-inner">' +
+        '<div class="detail-row"><span class="detail-key">Action</span><span class="detail-val">' + esc(entry.action || entry.action_id || '') + '</span></div>' +
+        '<div class="detail-row"><span class="detail-key">User</span><span class="detail-val">' + esc(entry.user || entry.operator || '-') + '</span></div>' +
+        '<div class="detail-row"><span class="detail-key">Result</span><span class="detail-val">' + (entry.ok || entry.success ? '<span class="badge badge-success">OK</span>' : '<span class="badge badge-critical">FAILED</span>') + '</span></div>' +
+        '<div class="detail-row"><span class="detail-key">Time</span><span class="detail-val">' + esc(entry.timestamp || '') + '</span></div>' +
+        (entry.params ? '<div class="detail-row"><span class="detail-key">Params</span><span class="detail-val" style="max-width:70%"><pre style="font-size:10px;color:#777;margin:0;white-space:pre-wrap">' + esc(JSON.stringify(entry.params, null, 2)) + '</pre></span></div>' : '') +
+        (entry.message ? '<div class="detail-row"><span class="detail-key">Message</span><span class="detail-val" style="max-width:70%">' + esc(entry.message) + '</span></div>' : '') +
+        '</div></div>'
+    }));
+    showResults(cards, 'Audit Trail (' + entries.length + ')');
+  } catch (e) {
+    showResults([{ html: noDataCard('Failed to load audit trail', esc(e.message)) }], 'Audit Trail');
+  }
+}
+
+async function renderActionsCatalog() {
+  try {
+    const catalog = await Actions.loadCatalog();
+    const actions = catalog?.actions || catalog || [];
+    if (!Array.isArray(actions) && typeof actions === 'object') {
+      // Handle object-style catalog
+      const entries = Object.entries(actions);
+      if (!entries.length) {
+        showResults([{ html: noDataCard('No actions available') }], 'Actions');
+        return;
+      }
+      const cards = entries.map(([id, info]) => ({
+        html: '<div class="card-header">' +
+          '<span class="card-icon">' + cardIcon('policy') + '</span>' +
+          '<span class="card-title" style="color:#3b82f6;font-weight:600">' + esc(id) + '</span>' +
+          '<span class="card-stat"><span class="badge badge-info">' + esc(info.risk || info.level || 'action') + '</span></span>' +
+          '<span class="card-chevron">\u25b8</span></div>' +
+          '<div class="card-body"><div class="card-body-inner">' +
+          '<div class="detail-row"><span class="detail-key">Description</span><span class="detail-val" style="max-width:70%">' + esc(info.description || info.desc || '-') + '</span></div>' +
+          (info.params ? '<div class="detail-row"><span class="detail-key">Parameters</span><span class="detail-val" style="max-width:70%"><pre style="font-size:10px;color:#777;margin:0;white-space:pre-wrap">' + esc(JSON.stringify(info.params, null, 2)) + '</pre></span></div>' : '') +
+          (info.confirm ? '<div class="detail-row"><span class="detail-key">Requires Confirm</span><span class="detail-val"><span class="badge badge-warning">YES</span></span></div>' : '') +
+          '</div></div>'
+      }));
+      showResults(cards, 'Available Actions (' + entries.length + ')');
+      return;
+    }
+    if (!actions.length) {
+      showResults([{ html: noDataCard('No actions available') }], 'Actions');
+      return;
+    }
+    const cards = actions.map(a => ({
+      html: '<div class="card-header">' +
+        '<span class="card-icon">' + cardIcon('policy') + '</span>' +
+        '<span class="card-title" style="color:#3b82f6;font-weight:600">' + esc(a.id || a.action_id || a.name || 'unknown') + '</span>' +
+        '<span class="card-stat"><span class="badge badge-info">' + esc(a.risk || a.level || 'action') + '</span></span>' +
+        '<span class="card-chevron">\u25b8</span></div>' +
+        '<div class="card-body"><div class="card-body-inner">' +
+        '<div class="detail-row"><span class="detail-key">Description</span><span class="detail-val" style="max-width:70%">' + esc(a.description || a.desc || '-') + '</span></div>' +
+        (a.params ? '<div class="detail-row"><span class="detail-key">Parameters</span><span class="detail-val" style="max-width:70%"><pre style="font-size:10px;color:#777;margin:0;white-space:pre-wrap">' + esc(JSON.stringify(a.params, null, 2)) + '</pre></span></div>' : '') +
+        (a.confirm ? '<div class="detail-row"><span class="detail-key">Requires Confirm</span><span class="detail-val"><span class="badge badge-warning">YES</span></span></div>' : '') +
+        '</div></div>'
+    }));
+    showResults(cards, 'Available Actions (' + actions.length + ')');
+  } catch (e) {
+    showResults([{ html: noDataCard('Failed to load actions catalog', esc(e.message)) }], 'Actions');
+  }
+}
+
+// =====================================================================
+// ACTION EXECUTION & CONFIRMATION
+// =====================================================================
+async function executeAction(actionId, params = {}) {
+  try {
+    const preview = await Actions.execute(actionId, params, { dryRun: true });
+    if (!preview.ok && !preview.confirm_token) {
+      showResults([makeActionResultCard(preview)], 'Action Failed');
+      return;
+    }
+    if (preview.confirm_token) {
+      // Show confirmation card
+      showResults([makeActionConfirmCard(preview, actionId, params)], 'Confirm Action');
+      setTimeout(() => toggleCard(0), 50);
+    } else {
+      // Low risk - execute directly
+      const result = await Actions.execute(actionId, params);
+      showResults([makeActionResultCard(result)], 'Action Result');
+      setTimeout(fetchAll, 1000); // refresh data
+    }
+  } catch (e) {
+    showResults([makeActionResultCard({ ok: false, message: 'Action failed: ' + e.message, detail: {} })], 'Action Failed');
+  }
+}
+
+async function confirmAction(actionId, params, token) {
+  try {
+    const result = await Actions.execute(actionId, params, { confirmToken: token });
+    showResults([makeActionResultCard(result)], 'Action Result');
+    setTimeout(fetchAll, 1000);
+  } catch (e) {
+    showResults([makeActionResultCard({ ok: false, message: 'Confirm failed: ' + e.message, detail: {} })], 'Action Failed');
+  }
+}
+
+function makeActionConfirmCard(preview, actionId, params) {
+  const paramsJson = JSON.stringify(params).replace(/'/g, '&#39;').replace(/"/g, '&quot;');
+  return {
+    html: '<div class="card-header">' +
+      '<span class="card-icon">&#9888;</span>' +
+      '<span class="card-title">' + esc(preview.message || 'Confirm action') + '</span>' +
+      '<span class="badge badge-warning">CONFIRM?</span></div>' +
+      '<div class="card-body"><div class="card-body-inner">' +
+      '<pre style="font-size:11px;color:#777;white-space:pre-wrap">' + esc(JSON.stringify(preview.detail, null, 2)) + '</pre>' +
+      '<div style="margin-top:12px;display:flex;gap:8px">' +
+      '<button class="action-confirm-btn confirm-yes" onclick="event.stopPropagation();confirmAction(\'' + esc(actionId) + '\',' + esc(JSON.stringify(params)) + ',\'' + esc(preview.confirm_token) + '\')">Confirm &amp; Execute</button>' +
+      '<button class="action-confirm-btn confirm-no" onclick="event.stopPropagation();clearResults()">Cancel</button>' +
+      '</div></div></div>'
+  };
+}
+
+function makeActionResultCard(result) {
+  const icon = result.ok ? '&#10003;' : '&#10007;';
+  const badge = result.ok ? 'success' : 'critical';
+  return {
+    html: '<div class="card-header">' +
+      '<span class="card-icon">' + icon + '</span>' +
+      '<span class="card-title">' + esc(result.message || (result.ok ? 'Action succeeded' : 'Action failed')) + '</span>' +
+      '<span class="badge badge-' + badge + '">' + (result.ok ? 'SUCCESS' : 'FAILED') + '</span></div>' +
+      (Object.keys(result.detail || {}).length ? '<div class="card-body"><div class="card-body-inner">' +
+      '<pre style="font-size:11px;color:#777;white-space:pre-wrap">' + esc(JSON.stringify(result.detail, null, 2)) + '</pre>' +
+      '</div></div>' : '')
+  };
+}
+
+// =====================================================================
+// AUTOCOMPLETE
+// =====================================================================
+let acItems = [];
+let acFocused = -1;
+
+function updateAutocomplete(value) {
+  const dropdown = document.getElementById('ac-dropdown');
+  const ghost = document.getElementById('cmd-ghost');
+
+  if (!value.startsWith('/') || value.includes(' ')) {
+    dropdown.classList.remove('open');
+    ghost.textContent = '';
+    acItems = [];
+    acFocused = -1;
+    return;
+  }
+
+  const q = value.toLowerCase();
+  const matches = [];
+
+  for (const cmd of COMMANDS) {
+    const score = fuzzyScore(q, cmd.cmd);
+    const aliasScores = cmd.aliases.map(a => fuzzyScore(q, a));
+    const maxAliasScore = aliasScores.length > 0 ? Math.max(...aliasScores) : 0;
+    const bestScore = Math.max(score, maxAliasScore);
+    if (bestScore > 0) {
+      matches.push({ ...cmd, score: bestScore });
+    }
+  }
+
+  matches.sort((a, b) => b.score - a.score);
+
+  if (!matches.length) {
+    dropdown.classList.remove('open');
+    ghost.textContent = '';
+    acItems = [];
+    acFocused = -1;
+    return;
+  }
+
+  acItems = matches;
+  acFocused = -1;
+
+  dropdown.innerHTML = matches.map((m, i) =>
+    '<div class="ac-item" data-idx="' + i + '">' +
+    '<span><span class="ac-cmd">' + esc(m.cmd) + '</span>' +
+    (m.aliases.length ? '<span class="ac-alias">' + m.aliases.map(a => esc(a)).join(' ') + '</span>' : '') +
+    '</span>' +
+    '<span class="ac-desc">' + esc(m.desc) + '</span>' +
+    '</div>'
+  ).join('');
+  dropdown.classList.add('open');
+
+  // Ghost text (autocomplete preview)
+  const topMatch = matches[0];
+  if (topMatch && topMatch.cmd.startsWith(q) && topMatch.cmd !== q) {
+    ghost.textContent = topMatch.cmd;
+  } else {
+    ghost.textContent = '';
+  }
+
+  // Click handlers
+  dropdown.querySelectorAll('.ac-item').forEach(item => {
+    item.addEventListener('click', () => {
+      const idx = parseInt(item.dataset.idx);
+      acceptAutocomplete(idx);
+    });
+  });
+}
+
+function acceptAutocomplete(idx) {
+  const item = acItems[idx >= 0 ? idx : 0];
+  if (!item) return;
+  const input = document.getElementById('cmd-input');
+  const needsArg = ['/lane', '/unblock', '/reprioritize', '/revoke', '/release-lock'].includes(item.cmd);
+  input.value = item.cmd + (needsArg ? ' ' : '');
+  document.getElementById('ac-dropdown').classList.remove('open');
+  document.getElementById('cmd-ghost').textContent = '';
+  acItems = [];
+  acFocused = -1;
+  input.focus();
+  if (!needsArg) {
+    executeQuery(input.value);
+  }
+}
+
+function focusAcItem(idx) {
+  const dropdown = document.getElementById('ac-dropdown');
+  dropdown.querySelectorAll('.ac-item').forEach(el => el.classList.remove('focused'));
+  acFocused = idx;
+  if (idx >= 0 && idx < acItems.length) {
+    const el = dropdown.querySelector('[data-idx="' + idx + '"]');
+    if (el) {
+      el.classList.add('focused');
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }
+}
+
+// =====================================================================
+// KEYBOARD HANDLING
+// =====================================================================
+const input = document.getElementById('cmd-input');
+
+input.addEventListener('input', () => {
+  updateAutocomplete(input.value);
+});
+
+input.addEventListener('keydown', (e) => {
+  const dropdown = document.getElementById('ac-dropdown');
+  const isAcOpen = dropdown.classList.contains('open');
+
+  // Tab: accept autocomplete
+  if (e.key === 'Tab') {
+    e.preventDefault();
+    if (isAcOpen && acItems.length > 0) {
+      acceptAutocomplete(acFocused >= 0 ? acFocused : 0);
+    }
+    return;
+  }
+
+  // Enter
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (isAcOpen && acFocused >= 0) {
+      acceptAutocomplete(acFocused);
+    } else if (S.currentResults.length > 0 && S.focusedCard >= 0) {
+      toggleCard(S.focusedCard);
+    } else {
+      executeQuery(input.value);
+    }
+    return;
+  }
+
+  // Escape
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    if (isAcOpen) {
+      dropdown.classList.remove('open');
+      document.getElementById('cmd-ghost').textContent = '';
+      acItems = [];
+      acFocused = -1;
+    } else if (S.currentResults.length > 0) {
+      clearResults();
+    } else {
+      input.value = '';
+    }
+    return;
+  }
+
+  // Arrow keys
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    if (isAcOpen) {
+      focusAcItem(Math.min(acFocused + 1, acItems.length - 1));
+    } else if (S.currentResults.length > 0) {
+      const next = Math.min(S.focusedCard + 1, S.currentResults.length - 1);
+      focusCard(next);
+    }
+    return;
+  }
+
+  if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (isAcOpen) {
+      focusAcItem(Math.max(acFocused - 1, 0));
+    } else if (S.currentResults.length > 0 && S.focusedCard > 0) {
+      focusCard(S.focusedCard - 1);
+    } else if (S.currentResults.length === 0 || S.focusedCard <= 0) {
+      // Command history
+      if (S.commandHistory.length > 0) {
+        if (S.historyPos === -1) {
+          S.historyPos = S.commandHistory.length - 1;
+        } else if (S.historyPos > 0) {
+          S.historyPos--;
+        }
+        input.value = S.commandHistory[S.historyPos];
+        updateAutocomplete(input.value);
+      }
+    }
+    return;
+  }
+});
+
+// Global keyboard shortcuts
+document.addEventListener('keydown', (e) => {
+  // Cmd/Ctrl+K: focus command bar
+  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    e.preventDefault();
+    input.focus();
+    input.select();
+    return;
+  }
+
+  // If not focused on input, redirect keystrokes to input
+  if (document.activeElement !== input && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    if (e.key.length === 1 || e.key === 'Backspace') {
+      input.focus();
+    }
+  }
+});
+
+// =====================================================================
+// INITIALIZATION
+// =====================================================================
+input.focus();
+startPolling();
+Actions.loadCatalog();
+</script>
+</body>
+</html>

--- a/tests/test_dashboard_actions.py
+++ b/tests/test_dashboard_actions.py
@@ -1,0 +1,895 @@
+"""Tests for the dashboard action system (dashboard_actions.py + dashboard_v2.py POST routes)."""
+
+import json
+import pathlib
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime, timezone
+from http.server import ThreadingHTTPServer
+from unittest import mock
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orxaq_autonomy import dashboard_actions, dashboard_v2
+
+
+# ── Test Fixtures ────────────────────────────────────────────────────────────
+
+def build_fixture(root: pathlib.Path) -> pathlib.Path:
+    """Build a minimal fixture tree for action testing. Returns artifacts_dir."""
+    # config/tasks.json
+    config_dir = root / "config"
+    config_dir.mkdir(parents=True)
+    tasks = [
+        {"id": "task-alpha", "owner": "codex", "priority": 1, "title": "Alpha",
+         "description": "First task", "depends_on": [], "acceptance": []},
+        {"id": "task-beta", "owner": "gemini", "priority": 3, "title": "Beta",
+         "description": "Second task", "depends_on": ["task-alpha"], "acceptance": []},
+        {"id": "task-gamma", "owner": "codex", "priority": 2, "title": "Gamma",
+         "description": "Third task", "depends_on": [], "acceptance": []},
+    ]
+    (config_dir / "tasks.json").write_text(json.dumps(tasks), encoding="utf-8")
+
+    # state/state.json
+    state_dir = root / "state"
+    state_dir.mkdir(parents=True)
+    state = {
+        "task-alpha": {"status": "done", "attempts": 1, "retryable_failures": 0,
+                       "last_error": "", "last_summary": "completed", "owner": "codex",
+                       "not_before": "", "last_update": "2026-02-12T00:00:00Z"},
+        "task-beta": {"status": "blocked", "attempts": 5, "retryable_failures": 3,
+                      "last_error": "timeout after 300s", "last_summary": "stuck on tests",
+                      "owner": "gemini", "not_before": "2026-02-12T06:00:00Z",
+                      "last_update": "2026-02-12T01:00:00Z"},
+        "task-gamma": {"status": "pending", "attempts": 0, "retryable_failures": 0,
+                       "last_error": "", "last_summary": "", "owner": "codex",
+                       "not_before": "", "last_update": ""},
+    }
+    (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    # artifacts/autonomy/
+    artifacts_dir = root / "artifacts"
+    auto_dir = artifacts_dir / "autonomy"
+    auto_dir.mkdir(parents=True)
+    (auto_dir / "health.json").write_text('{"ok": true}', encoding="utf-8")
+
+    # Minimal lane for snapshot to work
+    lane_dir = auto_dir / "lanes" / "test-lane"
+    lane_dir.mkdir(parents=True)
+    (lane_dir / "lane.json").write_text('{"owner": "codex"}', encoding="utf-8")
+    (lane_dir / "state.json").write_text(
+        '{"task-alpha": {"status": "done", "attempts": 1}}', encoding="utf-8")
+    (lane_dir / "heartbeat.json").write_text(json.dumps({
+        "cycle": 1, "phase": "idle", "pid": 1,
+        "timestamp": datetime.now(timezone.utc).isoformat()}), encoding="utf-8")
+
+    return artifacts_dir
+
+
+# ── AuditLog Tests ───────────────────────────────────────────────────────────
+
+class AuditLogTests(unittest.TestCase):
+    """Tests for ActionAuditLog."""
+
+    def test_log_creates_file_and_appends(self):
+        with tempfile.TemporaryDirectory() as td:
+            log_path = pathlib.Path(td) / "sub" / "audit.ndjson"
+            audit = dashboard_actions.ActionAuditLog(log_path)
+            audit.log({"action_id": "test.one", "ok": True})
+            audit.log({"action_id": "test.two", "ok": False})
+            lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["action_id"], "test.one")
+            self.assertEqual(json.loads(lines[1])["action_id"], "test.two")
+
+    def test_recent_reads_tail(self):
+        with tempfile.TemporaryDirectory() as td:
+            log_path = pathlib.Path(td) / "audit.ndjson"
+            audit = dashboard_actions.ActionAuditLog(log_path)
+            for i in range(10):
+                audit.log({"i": i})
+            entries = audit.recent(tail=3)
+            self.assertEqual(len(entries), 3)
+            self.assertEqual(entries[0]["i"], 7)
+
+    def test_recent_empty_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            log_path = pathlib.Path(td) / "audit.ndjson"
+            audit = dashboard_actions.ActionAuditLog(log_path)
+            entries = audit.recent()
+            self.assertEqual(entries, [])
+
+
+# ── Confirmation Token Tests ─────────────────────────────────────────────────
+
+class ConfirmTokenTests(unittest.TestCase):
+    """Tests for the two-phase confirmation token system."""
+
+    def setUp(self):
+        dashboard_actions._PENDING_CONFIRMATIONS.clear()
+
+    def test_generate_and_validate(self):
+        token = dashboard_actions.generate_confirm_token("test.action", {"key": "val"})
+        self.assertTrue(token.startswith("tok-"))
+        self.assertTrue(dashboard_actions.validate_confirm_token(token, "test.action"))
+
+    def test_single_use(self):
+        token = dashboard_actions.generate_confirm_token("test.action", {})
+        self.assertTrue(dashboard_actions.validate_confirm_token(token, "test.action"))
+        # Second use fails
+        self.assertFalse(dashboard_actions.validate_confirm_token(token, "test.action"))
+
+    def test_wrong_action_id(self):
+        token = dashboard_actions.generate_confirm_token("action.a", {})
+        self.assertFalse(dashboard_actions.validate_confirm_token(token, "action.b"))
+
+    def test_nonexistent_token(self):
+        self.assertFalse(dashboard_actions.validate_confirm_token("tok-nonexistent", "test"))
+
+    def test_expired_token(self):
+        token = dashboard_actions.generate_confirm_token("test.action", {})
+        # Manually expire it
+        dashboard_actions._PENDING_CONFIRMATIONS[token]["expires_at"] = time.time() - 1
+        self.assertFalse(dashboard_actions.validate_confirm_token(token, "test.action"))
+
+
+# ── Rate Limiter Tests ───────────────────────────────────────────────────────
+
+class RateLimiterTests(unittest.TestCase):
+    """Tests for the rate limiting system."""
+
+    def setUp(self):
+        dashboard_actions.reset_rate_limits()
+
+    def test_allows_within_limit(self):
+        for _ in range(5):
+            self.assertIsNone(dashboard_actions.check_rate_limit("low"))
+
+    def test_rejects_over_global_limit(self):
+        for _ in range(dashboard_actions.RATE_LIMIT_GLOBAL):
+            dashboard_actions.check_rate_limit("low")
+        result = dashboard_actions.check_rate_limit("low")
+        self.assertIn("Rate limit", result)
+
+    def test_high_risk_separate_limit(self):
+        for _ in range(dashboard_actions.RATE_LIMIT_HIGH):
+            dashboard_actions.check_rate_limit("high")
+        result = dashboard_actions.check_rate_limit("high")
+        self.assertIn("high-risk", result)
+
+
+# ── Task Reprioritize Tests ──────────────────────────────────────────────────
+
+class TaskReprioritizeTests(unittest.TestCase):
+
+    def test_reprioritize_success(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_reprioritize(
+                ctx, {"task_id": "task-beta", "new_priority": 1}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertEqual(result.detail["new_priority"], 1)
+            self.assertEqual(result.detail["old_priority"], 3)
+            # Verify file was updated
+            tasks = json.loads((root / "config" / "tasks.json").read_text())
+            beta = next(t for t in tasks if t["id"] == "task-beta")
+            self.assertEqual(beta["priority"], 1)
+
+    def test_reprioritize_dry_run(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_reprioritize(
+                ctx, {"task_id": "task-beta", "new_priority": 1}, dry_run=True)
+            self.assertTrue(result.ok)
+            self.assertTrue(result.dry_run)
+            # Verify file was NOT updated
+            tasks = json.loads((root / "config" / "tasks.json").read_text())
+            beta = next(t for t in tasks if t["id"] == "task-beta")
+            self.assertEqual(beta["priority"], 3)
+
+    def test_reprioritize_invalid_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_reprioritize(
+                ctx, {"task_id": "nonexistent", "new_priority": 1}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("not found", result.message)
+
+    def test_reprioritize_invalid_priority(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_reprioritize(
+                ctx, {"task_id": "task-beta", "new_priority": 1500}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("0-999", result.message)
+
+
+# ── Task Update Status Tests ────────────────────────────────────────────────
+
+class TaskUpdateStatusTests(unittest.TestCase):
+
+    def test_unblock_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_update_status(
+                ctx, {"task_id": "task-beta", "new_status": "pending"}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertEqual(result.detail["previous_status"], "blocked")
+            self.assertEqual(result.detail["new_status"], "pending")
+            # Verify state file
+            state = json.loads((root / "state" / "state.json").read_text())
+            self.assertEqual(state["task-beta"]["status"], "pending")
+            self.assertEqual(state["task-beta"]["last_error"], "")
+            self.assertEqual(state["task-beta"]["not_before"], "")
+
+    def test_rejects_in_progress_status(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_update_status(
+                ctx, {"task_id": "task-beta", "new_status": "in_progress"}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("Invalid status", result.message)
+
+    def test_rejects_nonexistent_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_update_status(
+                ctx, {"task_id": "no-such", "new_status": "pending"}, dry_run=False)
+            self.assertFalse(result.ok)
+
+    def test_dry_run_does_not_modify(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_update_status(
+                ctx, {"task_id": "task-beta", "new_status": "pending"}, dry_run=True)
+            self.assertTrue(result.ok)
+            state = json.loads((root / "state" / "state.json").read_text())
+            self.assertEqual(state["task-beta"]["status"], "blocked")
+
+
+# ── Task Clear Error Tests ───────────────────────────────────────────────────
+
+class TaskClearErrorTests(unittest.TestCase):
+
+    def test_clear_error_and_unblock(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_clear_error(
+                ctx, {"task_id": "task-beta"}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertEqual(result.detail["cleared_failures"], 3)
+            state = json.loads((root / "state" / "state.json").read_text())
+            self.assertEqual(state["task-beta"]["status"], "pending")
+            self.assertEqual(state["task-beta"]["last_error"], "")
+            self.assertEqual(state["task-beta"]["retryable_failures"], 0)
+
+    def test_clear_error_on_pending_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_task_clear_error(
+                ctx, {"task_id": "task-gamma"}, dry_run=False)
+            self.assertTrue(result.ok)
+            state = json.loads((root / "state" / "state.json").read_text())
+            self.assertEqual(state["task-gamma"]["status"], "pending")
+
+
+# ── Breakglass Grant Tests ───────────────────────────────────────────────────
+
+class BreakglassGrantTests(unittest.TestCase):
+
+    def test_grant_dry_run(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            dashboard_actions._PENDING_CONFIRMATIONS.clear()
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_breakglass_grant(
+                ctx, {"reason": "Test", "scope": "test scope", "ttl_minutes": 15}, dry_run=True)
+            self.assertTrue(result.ok)
+            self.assertTrue(result.dry_run)
+            self.assertIsNotNone(result.confirm_token)
+
+    def test_grant_creates_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_breakglass_grant(
+                ctx, {"reason": "Unblock PR", "scope": "no-verify push",
+                      "ttl_minutes": 20, "task_allowlist": ["task-beta"]},
+                dry_run=False)
+            self.assertTrue(result.ok)
+            grant_id = result.detail["grant_id"]
+            # Verify grant file exists
+            grant_path = root / "artifacts" / "autonomy" / "breakglass" / "grants" / f"{grant_id}.json"
+            self.assertTrue(grant_path.exists())
+            grant_data = json.loads(grant_path.read_text())
+            self.assertEqual(grant_data["scope"], "no-verify push")
+            self.assertEqual(grant_data["ttl_minutes"], 20)
+            # Verify escalation logged
+            esc_path = root / "artifacts" / "autonomy" / "privilege_escalations.ndjson"
+            self.assertTrue(esc_path.exists())
+            lines = esc_path.read_text().strip().splitlines()
+            self.assertTrue(any("breakglass_grant_created" in l for l in lines))
+
+    def test_grant_rejects_missing_reason(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_breakglass_grant(
+                ctx, {"scope": "test", "ttl_minutes": 15}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("reason", result.message)
+
+    def test_grant_rejects_excessive_ttl(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_breakglass_grant(
+                ctx, {"reason": "Test", "scope": "test", "ttl_minutes": 9999}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("1-1440", result.message)
+
+
+# ── Breakglass Revoke Tests ──────────────────────────────────────────────────
+
+class BreakglassRevokeTests(unittest.TestCase):
+
+    def test_revoke_existing_grant(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            # First create a grant
+            create_result = dashboard_actions.action_breakglass_grant(
+                ctx, {"reason": "Test", "scope": "test scope", "ttl_minutes": 10}, dry_run=False)
+            grant_id = create_result.detail["grant_id"]
+            # Now revoke it
+            result = dashboard_actions.action_breakglass_revoke(
+                ctx, {"grant_id": grant_id}, dry_run=False)
+            self.assertTrue(result.ok)
+            # Verify grant file was removed
+            grant_path = root / "artifacts" / "autonomy" / "breakglass" / "grants" / f"{grant_id}.json"
+            self.assertFalse(grant_path.exists())
+
+    def test_revoke_nonexistent_grant(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_breakglass_revoke(
+                ctx, {"grant_id": "bg-nonexistent"}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("not found", result.message)
+
+
+# ── Git Heal Locks Tests ─────────────────────────────────────────────────────
+
+class GitHealLocksTests(unittest.TestCase):
+
+    def test_heal_no_locks(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            ctx = dashboard_actions.build_context(root / "artifacts", root)
+            result = dashboard_actions.action_git_heal_locks(ctx, {}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertIn("No stale", result.message)
+
+    def test_heal_removes_locks(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            # Create stale lock files
+            (git_dir / "index.lock").write_text("lock", encoding="utf-8")
+            (git_dir / "HEAD.lock").write_text("lock", encoding="utf-8")
+            ctx = dashboard_actions.build_context(root / "artifacts", root)
+            result = dashboard_actions.action_git_heal_locks(ctx, {}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertIn("2", result.message)
+            self.assertFalse((git_dir / "index.lock").exists())
+            self.assertFalse((git_dir / "HEAD.lock").exists())
+
+    def test_heal_dry_run_does_not_remove(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            (git_dir / "index.lock").write_text("lock", encoding="utf-8")
+            dashboard_actions._PENDING_CONFIRMATIONS.clear()
+            ctx = dashboard_actions.build_context(root / "artifacts", root)
+            result = dashboard_actions.action_git_heal_locks(ctx, {}, dry_run=True)
+            self.assertTrue(result.ok)
+            self.assertIsNotNone(result.confirm_token)
+            self.assertTrue((git_dir / "index.lock").exists())
+
+    def test_heal_no_repo_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_git_heal_locks(ctx, {}, dry_run=False)
+            self.assertFalse(result.ok)
+            self.assertIn("repo_dir", result.message)
+
+
+# ── Runner Release Lock Tests ────────────────────────────────────────────────
+
+class RunnerReleaseLockTests(unittest.TestCase):
+
+    def test_no_lock_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_runner_release_lock(ctx, {}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertIn("No runner lock", result.message)
+
+    def test_removes_stale_lock(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            lock_path = root / "artifacts" / "autonomy" / "runner.lock"
+            lock_path.write_text(json.dumps({"pid": 999999, "created_at": "2026-01-01T00:00:00Z"}),
+                                 encoding="utf-8")
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_runner_release_lock(ctx, {}, dry_run=False)
+            self.assertTrue(result.ok)
+            self.assertFalse(lock_path.exists())
+
+
+# ── Runner Subprocess Action Tests ───────────────────────────────────────────
+
+class RunnerSubprocessTests(unittest.TestCase):
+
+    @mock.patch("orxaq_autonomy.dashboard_actions.subprocess.run")
+    def test_stop_dry_run_no_subprocess(self, mock_run):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            dashboard_actions._PENDING_CONFIRMATIONS.clear()
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_runner_stop(
+                ctx, {"reason": "test"}, dry_run=True)
+            self.assertTrue(result.ok)
+            self.assertIsNotNone(result.confirm_token)
+            mock_run.assert_not_called()
+
+    @mock.patch("orxaq_autonomy.dashboard_actions.subprocess.run")
+    def test_stop_calls_cli(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=0, stdout="stopped", stderr="")
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_runner_stop(
+                ctx, {"reason": "manual"}, dry_run=False)
+            self.assertTrue(result.ok)
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            self.assertIn("stop", call_args)
+            self.assertIn("manual", call_args)
+
+    @mock.patch("orxaq_autonomy.dashboard_actions.subprocess.run")
+    def test_start_calls_cli(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=0, stdout="started", stderr="")
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_runner_start(ctx, {}, dry_run=False)
+            self.assertTrue(result.ok)
+            call_args = mock_run.call_args[0][0]
+            self.assertIn("start", call_args)
+
+    @mock.patch("orxaq_autonomy.dashboard_actions.subprocess.run")
+    def test_ensure_calls_cli(self, mock_run):
+        mock_run.return_value = mock.Mock(returncode=0, stdout="ensured", stderr="")
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            ctx = dashboard_actions.build_context(root / "artifacts", None)
+            result = dashboard_actions.action_runner_ensure(ctx, {}, dry_run=False)
+            self.assertTrue(result.ok)
+            call_args = mock_run.call_args[0][0]
+            self.assertIn("ensure", call_args)
+
+
+# ── Action Catalog Tests ─────────────────────────────────────────────────────
+
+class ActionCatalogTests(unittest.TestCase):
+
+    def test_catalog_lists_all_actions(self):
+        catalog = dashboard_actions.get_action_catalog()
+        self.assertIsInstance(catalog, list)
+        action_ids = {a["action_id"] for a in catalog}
+        self.assertIn("task.reprioritize", action_ids)
+        self.assertIn("task.update-status", action_ids)
+        self.assertIn("task.clear-error", action_ids)
+        self.assertIn("breakglass.grant", action_ids)
+        self.assertIn("breakglass.revoke", action_ids)
+        self.assertIn("git.heal-locks", action_ids)
+        self.assertIn("runner.release-lock", action_ids)
+        self.assertIn("runner.stop", action_ids)
+        self.assertIn("runner.start", action_ids)
+        self.assertIn("runner.ensure", action_ids)
+
+    def test_catalog_has_required_fields(self):
+        catalog = dashboard_actions.get_action_catalog()
+        for action in catalog:
+            self.assertIn("action_id", action)
+            self.assertIn("risk_level", action)
+            self.assertIn("description", action)
+            self.assertIn("requires_confirmation", action)
+            self.assertIn("param_schema", action)
+
+
+# ── Dispatch Tests ───────────────────────────────────────────────────────────
+
+class DispatchTests(unittest.TestCase):
+
+    def setUp(self):
+        dashboard_actions.reset_rate_limits()
+        dashboard_actions._PENDING_CONFIRMATIONS.clear()
+
+    def test_dispatch_unknown_action(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            result = dashboard_actions.dispatch_action(
+                action_id="nonexistent.action",
+                params={},
+                confirm_token="",
+                dry_run=False,
+                artifacts_dir=root / "artifacts",
+                repo_dir=None,
+            )
+            self.assertFalse(result.ok)
+            self.assertIn("Unknown action", result.message)
+
+    def test_dispatch_low_risk_executes_without_token(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            result = dashboard_actions.dispatch_action(
+                action_id="task.clear-error",
+                params={"task_id": "task-beta"},
+                confirm_token="",
+                dry_run=False,
+                artifacts_dir=root / "artifacts",
+                repo_dir=None,
+            )
+            self.assertTrue(result.ok)
+            self.assertIsNotNone(result.audit_id)
+
+    def test_dispatch_medium_risk_requires_confirmation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            (git_dir / "index.lock").write_text("lock", encoding="utf-8")
+            # Without confirmation
+            result = dashboard_actions.dispatch_action(
+                action_id="git.heal-locks",
+                params={},
+                confirm_token="",
+                dry_run=False,
+                artifacts_dir=root / "artifacts",
+                repo_dir=root,
+            )
+            self.assertFalse(result.ok)
+            self.assertIn("confirmation", result.message.lower())
+
+    def test_dispatch_two_phase_confirmation_flow(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            (git_dir / "index.lock").write_text("lock", encoding="utf-8")
+
+            # Phase 1: dry run to get token
+            preview = dashboard_actions.dispatch_action(
+                action_id="git.heal-locks",
+                params={},
+                confirm_token="",
+                dry_run=True,
+                artifacts_dir=root / "artifacts",
+                repo_dir=root,
+            )
+            self.assertTrue(preview.ok)
+            self.assertIsNotNone(preview.confirm_token)
+
+            # Phase 2: execute with token
+            result = dashboard_actions.dispatch_action(
+                action_id="git.heal-locks",
+                params={},
+                confirm_token=preview.confirm_token,
+                dry_run=False,
+                artifacts_dir=root / "artifacts",
+                repo_dir=root,
+            )
+            self.assertTrue(result.ok)
+            self.assertFalse((git_dir / "index.lock").exists())
+
+    def test_dispatch_logs_to_audit(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            result = dashboard_actions.dispatch_action(
+                action_id="task.reprioritize",
+                params={"task_id": "task-beta", "new_priority": 1},
+                confirm_token="",
+                dry_run=False,
+                artifacts_dir=root / "artifacts",
+                repo_dir=None,
+            )
+            self.assertTrue(result.ok)
+            audit_path = root / "artifacts" / "autonomy" / "dashboard_actions_audit.ndjson"
+            self.assertTrue(audit_path.exists())
+            entries = json.loads(audit_path.read_text().strip().splitlines()[0])
+            self.assertEqual(entries["action_id"], "task.reprioritize")
+            self.assertTrue(entries["result_ok"])
+
+    def test_dispatch_dry_run_skips_audit(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            dashboard_actions.dispatch_action(
+                action_id="task.reprioritize",
+                params={"task_id": "task-beta", "new_priority": 1},
+                confirm_token="",
+                dry_run=True,
+                artifacts_dir=root / "artifacts",
+                repo_dir=None,
+            )
+            audit_path = root / "artifacts" / "autonomy" / "dashboard_actions_audit.ndjson"
+            self.assertFalse(audit_path.exists())
+
+
+# ── HTTP Integration Tests ───────────────────────────────────────────────────
+
+class ActionHTTPTests(unittest.TestCase):
+    """Integration tests for the POST action endpoints."""
+
+    def setUp(self):
+        dashboard_actions.reset_rate_limits()
+        dashboard_actions._PENDING_CONFIRMATIONS.clear()
+
+    def _start_server(self, artifacts_dir, repo_dir=None):
+        handler = dashboard_v2.make_v2_handler(artifacts_dir, repo_dir=repo_dir)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, thread
+
+    def _post(self, base, path, body):
+        data = json.dumps(body).encode("utf-8")
+        req = urllib_request.Request(
+            f"{base}{path}", data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib_request.urlopen(req, timeout=5) as resp:
+                return resp.status, json.loads(resp.read().decode("utf-8"))
+        except urllib_error.HTTPError as err:
+            body = json.loads(err.read().decode("utf-8"))
+            code = err.code
+            err.close()
+            return code, body
+
+    def test_get_action_catalog(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            server, thread = self._start_server(root / "artifacts")
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/actions", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIsInstance(data, list)
+                    self.assertTrue(len(data) >= 10)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_post_low_risk_action(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            server, thread = self._start_server(root / "artifacts")
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                status, data = self._post(base, "/api/v2/actions/task.clear-error",
+                                          {"params": {"task_id": "task-beta"}})
+                self.assertEqual(status, 200)
+                self.assertTrue(data["ok"])
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_post_unknown_action_404(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            server, thread = self._start_server(root / "artifacts")
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                status, data = self._post(base, "/api/v2/actions/bogus.action",
+                                          {"params": {}})
+                self.assertEqual(status, 404)
+                self.assertFalse(data["ok"])
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_post_medium_risk_without_token_409(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            (git_dir / "index.lock").write_text("lock", encoding="utf-8")
+            server, thread = self._start_server(root / "artifacts", repo_dir=root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                status, data = self._post(base, "/api/v2/actions/git.heal-locks",
+                                          {"params": {}})
+                self.assertEqual(status, 409)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_post_two_phase_confirm_flow(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            (git_dir / "index.lock").write_text("lock", encoding="utf-8")
+            server, thread = self._start_server(root / "artifacts", repo_dir=root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                # Phase 1: dry run
+                s1, d1 = self._post(base, "/api/v2/actions/git.heal-locks",
+                                    {"params": {}, "dry_run": True})
+                self.assertEqual(s1, 200)
+                self.assertTrue(d1["ok"])
+                token = d1["confirm_token"]
+                self.assertIsNotNone(token)
+                # Phase 2: execute
+                s2, d2 = self._post(base, "/api/v2/actions/git.heal-locks",
+                                    {"params": {}, "confirm_token": token})
+                self.assertEqual(s2, 200)
+                self.assertTrue(d2["ok"])
+                self.assertFalse((git_dir / "index.lock").exists())
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_options_cors_preflight(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            server, thread = self._start_server(root / "artifacts")
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                req = urllib_request.Request(
+                    f"{base}/api/v2/actions/task.clear-error",
+                    method="OPTIONS",
+                )
+                with urllib_request.urlopen(req, timeout=5) as resp:
+                    self.assertEqual(resp.status, 204)
+                    self.assertEqual(resp.headers.get("Access-Control-Allow-Methods"),
+                                     "GET, POST, OPTIONS")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_get_audit_trail(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            server, thread = self._start_server(root / "artifacts")
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                # Execute an action to generate audit entry
+                self._post(base, "/api/v2/actions/task.clear-error",
+                           {"params": {"task_id": "task-beta"}})
+                # Fetch audit trail
+                with urllib_request.urlopen(f"{base}/api/v2/actions/audit", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIsInstance(data, list)
+                    self.assertTrue(len(data) >= 1)
+                    self.assertEqual(data[0]["action_id"], "task.clear-error")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_invalid_json_body_400(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            build_fixture(root)
+            server, thread = self._start_server(root / "artifacts")
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                req = urllib_request.Request(
+                    f"{base}/api/v2/actions/task.clear-error",
+                    data=b"not json",
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                try:
+                    urllib_request.urlopen(req, timeout=5)
+                    self.fail("Expected HTTP 400")
+                except urllib_error.HTTPError as err:
+                    self.assertEqual(err.code, 400)
+                    err.close()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+
+# ── ActionResult Tests ───────────────────────────────────────────────────────
+
+class ActionResultTests(unittest.TestCase):
+
+    def test_to_dict(self):
+        result = dashboard_actions.ActionResult(
+            ok=True, action_id="test", dry_run=False, message="ok",
+            detail={"key": "val"}, audit_id="aud-1", confirm_token=None)
+        d = result.to_dict()
+        self.assertEqual(d["ok"], True)
+        self.assertEqual(d["action_id"], "test")
+        self.assertEqual(d["detail"]["key"], "val")
+        self.assertIsNone(d["confirm_token"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_v2.py
+++ b/tests/test_dashboard_v2.py
@@ -1,0 +1,1248 @@
+"""Comprehensive tests for the v2 swarm command dashboard."""
+
+import json
+import pathlib
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from datetime import datetime, timezone, timedelta
+from http.server import ThreadingHTTPServer
+from unittest import mock
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from orxaq_autonomy import dashboard_v2
+
+
+class HelperTests(unittest.TestCase):
+    """Tests for low-level helper functions."""
+
+    def test_utc_now_iso_returns_iso_string(self):
+        result = dashboard_v2._utc_now_iso()
+        # Should be parseable as ISO 8601
+        parsed = datetime.fromisoformat(result)
+        self.assertIsNotNone(parsed.tzinfo)
+
+    def test_read_json_returns_dict_for_valid_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "data.json"
+            path.write_text('{"key": "value"}', encoding="utf-8")
+            result = dashboard_v2._read_json(path)
+            self.assertEqual(result, {"key": "value"})
+
+    def test_read_json_returns_list_for_array(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "data.json"
+            path.write_text('[1, 2, 3]', encoding="utf-8")
+            result = dashboard_v2._read_json(path)
+            self.assertEqual(result, [1, 2, 3])
+
+    def test_read_json_returns_empty_dict_for_missing_file(self):
+        result = dashboard_v2._read_json(pathlib.Path("/nonexistent/file.json"))
+        self.assertEqual(result, {})
+
+    def test_read_json_returns_empty_dict_for_invalid_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "bad.json"
+            path.write_text("not json!", encoding="utf-8")
+            result = dashboard_v2._read_json(path)
+            self.assertEqual(result, {})
+
+    def test_read_json_returns_empty_dict_for_scalar(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "scalar.json"
+            path.write_text('"just a string"', encoding="utf-8")
+            result = dashboard_v2._read_json(path)
+            self.assertEqual(result, {})
+
+    def test_read_json_dict_returns_dict(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "data.json"
+            path.write_text('{"a": 1}', encoding="utf-8")
+            result = dashboard_v2._read_json_dict(path)
+            self.assertEqual(result, {"a": 1})
+
+    def test_read_json_dict_returns_empty_for_array(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "data.json"
+            path.write_text('[1, 2]', encoding="utf-8")
+            result = dashboard_v2._read_json_dict(path)
+            self.assertEqual(result, {})
+
+    def test_read_ndjson_parses_lines(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "events.ndjson"
+            lines = [
+                '{"type": "a", "ts": 1}',
+                '{"type": "b", "ts": 2}',
+                '{"type": "c", "ts": 3}',
+            ]
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            result = dashboard_v2._read_ndjson(path, tail=10)
+            self.assertEqual(len(result), 3)
+            self.assertEqual(result[0]["type"], "a")
+
+    def test_read_ndjson_respects_tail(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "events.ndjson"
+            lines = [json.dumps({"i": i}) for i in range(20)]
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            result = dashboard_v2._read_ndjson(path, tail=5)
+            self.assertEqual(len(result), 5)
+            self.assertEqual(result[0]["i"], 15)
+
+    def test_read_ndjson_skips_invalid_lines(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "events.ndjson"
+            path.write_text('{"ok":1}\nnot json\n{"ok":2}\n', encoding="utf-8")
+            result = dashboard_v2._read_ndjson(path)
+            self.assertEqual(len(result), 2)
+
+    def test_read_ndjson_returns_empty_for_missing(self):
+        result = dashboard_v2._read_ndjson(pathlib.Path("/nonexistent.ndjson"))
+        self.assertEqual(result, [])
+
+    def test_safe_int(self):
+        self.assertEqual(dashboard_v2._safe_int(42), 42)
+        self.assertEqual(dashboard_v2._safe_int("7"), 7)
+        self.assertEqual(dashboard_v2._safe_int(None), 0)
+        self.assertEqual(dashboard_v2._safe_int("bad", 99), 99)
+
+    def test_safe_float(self):
+        self.assertAlmostEqual(dashboard_v2._safe_float(3.14), 3.14)
+        self.assertAlmostEqual(dashboard_v2._safe_float("2.5"), 2.5)
+        self.assertEqual(dashboard_v2._safe_float(None), 0.0)
+        self.assertEqual(dashboard_v2._safe_float("bad", 1.0), 1.0)
+
+
+class LaneDiscoveryTests(unittest.TestCase):
+    """Tests for lane discovery and reading."""
+
+    def _make_lane(self, root, lane_id, *, owner="codex", tasks=None, heartbeat=None, config=None):
+        """Create a lane fixture directory with artifacts."""
+        lane_dir = root / "autonomy" / "lanes" / lane_id
+        lane_dir.mkdir(parents=True, exist_ok=True)
+
+        if tasks is None:
+            tasks = {
+                "task-1": {"status": "done", "attempts": 1, "deadlock_recoveries": 0,
+                           "last_update": "2025-01-01T00:00:00Z", "last_summary": "Complete"},
+                "task-2": {"status": "in_progress", "attempts": 2, "deadlock_recoveries": 1,
+                           "last_update": "2025-01-01T01:00:00Z", "last_summary": "Working"},
+            }
+        (lane_dir / "state.json").write_text(json.dumps(tasks), encoding="utf-8")
+
+        if heartbeat is None:
+            heartbeat = {"cycle": 10, "phase": "execute", "pid": 1234,
+                         "timestamp": datetime.now(timezone.utc).isoformat(), "message": "Running"}
+        (lane_dir / "heartbeat.json").write_text(json.dumps(heartbeat), encoding="utf-8")
+
+        lane_config = config or {"owner": owner, "execution_profile": "standard",
+                                  "continuous": True, "max_cycles": 100, "max_attempts": 5,
+                                  "started_at": "2025-01-01T00:00:00Z"}
+        (lane_dir / "lane.json").write_text(json.dumps(lane_config), encoding="utf-8")
+
+        metrics = {"responses_total": 50, "cost_usd_total": 0.25, "tokens_total": 10000,
+                   "first_time_pass_rate": 0.8, "acceptance_pass_rate": 0.9}
+        (lane_dir / "response_metrics_summary.json").write_text(json.dumps(metrics), encoding="utf-8")
+
+        return lane_dir
+
+    def test_discover_lanes_finds_all_lanes(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            self._make_lane(root, "lane-alpha", owner="codex")
+            self._make_lane(root, "lane-beta", owner="gemini")
+            self._make_lane(root, "lane-gamma", owner="claude")
+
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(len(lanes), 3)
+            ids = {l["lane_id"] for l in lanes}
+            self.assertEqual(ids, {"lane-alpha", "lane-beta", "lane-gamma"})
+
+    def test_discover_lanes_returns_empty_when_no_lanes_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            lanes = dashboard_v2.discover_lanes(pathlib.Path(td))
+            self.assertEqual(lanes, [])
+
+    def test_lane_status_derivation_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            tasks = {"t1": {"status": "blocked"}, "t2": {"status": "done"}}
+            self._make_lane(root, "blocked-lane", tasks=tasks)
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(len(lanes), 1)
+            self.assertEqual(lanes[0]["status"], "blocked")
+
+    def test_lane_status_derivation_in_progress(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            tasks = {"t1": {"status": "in_progress"}, "t2": {"status": "pending"}}
+            self._make_lane(root, "active-lane", tasks=tasks)
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(lanes[0]["status"], "in_progress")
+
+    def test_lane_status_derivation_done(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            tasks = {"t1": {"status": "done"}, "t2": {"status": "done"}}
+            self._make_lane(root, "done-lane", tasks=tasks)
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(lanes[0]["status"], "done")
+
+    def test_lane_status_derivation_idle(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            self._make_lane(root, "idle-lane", tasks={})
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(lanes[0]["status"], "idle")
+
+    def test_lane_task_counts(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            tasks = {
+                "a": {"status": "done"}, "b": {"status": "done"},
+                "c": {"status": "in_progress"}, "d": {"status": "pending"},
+                "e": {"status": "blocked"},
+            }
+            self._make_lane(root, "multi-lane", tasks=tasks)
+            lanes = dashboard_v2.discover_lanes(root)
+            tc = lanes[0]["task_counts"]
+            self.assertEqual(tc["done"], 2)
+            self.assertEqual(tc["in_progress"], 1)
+            self.assertEqual(tc["pending"], 1)
+            self.assertEqual(tc["blocked"], 1)
+
+    def test_lane_heartbeat_parsed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            hb = {"cycle": 42, "phase": "review", "pid": 9999,
+                  "timestamp": "2025-06-01T12:00:00Z", "message": "All good"}
+            self._make_lane(root, "hb-lane", heartbeat=hb)
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(lanes[0]["heartbeat"]["cycle"], 42)
+            self.assertEqual(lanes[0]["heartbeat"]["phase"], "review")
+            self.assertEqual(lanes[0]["heartbeat"]["pid"], 9999)
+
+    def test_lane_metrics_parsed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            self._make_lane(root, "metric-lane")
+            lanes = dashboard_v2.discover_lanes(root)
+            m = lanes[0]["metrics"]
+            self.assertEqual(m["responses_total"], 50)
+            self.assertAlmostEqual(m["cost_usd_total"], 0.25)
+            self.assertEqual(m["tokens_total"], 10000)
+
+    def test_lane_owner_from_config(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            self._make_lane(root, "owner-lane", owner="gemini")
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(lanes[0]["owner"], "gemini")
+
+    def test_ignores_files_in_lanes_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            self._make_lane(root, "real-lane")
+            # Place a file (not dir) in lanes/
+            (root / "autonomy" / "lanes" / "stray-file.txt").write_text("hi", encoding="utf-8")
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(len(lanes), 1)
+
+
+class EventCollectionTests(unittest.TestCase):
+    """Tests for collect_events."""
+
+    def test_collects_events_across_lanes(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            for lid in ("lane-a", "lane-b"):
+                lane_dir = root / "autonomy" / "lanes" / lid
+                lane_dir.mkdir(parents=True)
+                events = [json.dumps({"timestamp": f"2025-01-01T0{i}:00:00Z", "type": "task_done"})
+                          for i in range(3)]
+                (lane_dir / "conversations.ndjson").write_text("\n".join(events) + "\n", encoding="utf-8")
+
+            result = dashboard_v2.collect_events(root, tail=10)
+            self.assertEqual(len(result), 6)
+            # Check lane_id annotation
+            lane_ids = {e["lane_id"] for e in result}
+            self.assertEqual(lane_ids, {"lane-a", "lane-b"})
+
+    def test_events_sorted_descending(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "lane-x"
+            lane_dir.mkdir(parents=True)
+            events = [
+                json.dumps({"timestamp": "2025-01-01T01:00:00Z"}),
+                json.dumps({"timestamp": "2025-01-01T03:00:00Z"}),
+                json.dumps({"timestamp": "2025-01-01T02:00:00Z"}),
+            ]
+            (lane_dir / "conversations.ndjson").write_text("\n".join(events) + "\n", encoding="utf-8")
+
+            result = dashboard_v2.collect_events(root, tail=10)
+            timestamps = [e["timestamp"] for e in result]
+            self.assertEqual(timestamps, sorted(timestamps, reverse=True))
+
+    def test_events_tail_limits_result(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "lane-y"
+            lane_dir.mkdir(parents=True)
+            events = [json.dumps({"timestamp": f"2025-01-01T{i:02d}:00:00Z"}) for i in range(20)]
+            (lane_dir / "conversations.ndjson").write_text("\n".join(events) + "\n", encoding="utf-8")
+
+            result = dashboard_v2.collect_events(root, tail=5)
+            self.assertEqual(len(result), 5)
+
+    def test_events_empty_when_no_lanes(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_events(pathlib.Path(td))
+            self.assertEqual(result, [])
+
+
+class HealthTests(unittest.TestCase):
+    """Tests for collect_health."""
+
+    def test_reads_health_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            auto_dir = root / "autonomy"
+            auto_dir.mkdir(parents=True)
+            (auto_dir / "health.json").write_text('{"status": "green"}', encoding="utf-8")
+            (auto_dir / "dashboard_health.json").write_text('{"collab": true}', encoding="utf-8")
+
+            result = dashboard_v2.collect_health(root)
+            self.assertEqual(result["health"]["status"], "green")
+            self.assertTrue(result["collaboration"]["collab"])
+            self.assertIn("timestamp", result)
+
+    def test_health_empty_when_no_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_health(pathlib.Path(td))
+            self.assertEqual(result["health"], {})
+            self.assertEqual(result["collaboration"], {})
+
+
+class MetricsTests(unittest.TestCase):
+    """Tests for collect_metrics."""
+
+    def test_reads_global_and_per_lane_metrics(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            auto_dir = root / "autonomy"
+            auto_dir.mkdir(parents=True)
+            (auto_dir / "response_metrics_summary.json").write_text(
+                '{"responses_total": 100, "cost_usd_total": 2.50}', encoding="utf-8")
+
+            lane_dir = auto_dir / "lanes" / "lane-a"
+            lane_dir.mkdir(parents=True)
+            (lane_dir / "response_metrics_summary.json").write_text(
+                '{"responses_total": 30, "cost_usd_total": 0.80}', encoding="utf-8")
+
+            result = dashboard_v2.collect_metrics(root)
+            self.assertEqual(result["global"]["responses_total"], 100)
+            self.assertIn("lane-a", result["per_lane"])
+            self.assertEqual(result["per_lane"]["lane-a"]["responses_total"], 30)
+
+
+class GitStateTests(unittest.TestCase):
+    """Tests for collect_git_state."""
+
+    def test_returns_structure_for_non_repo(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_git_state(pathlib.Path(td))
+            self.assertIn("branches", result)
+            self.assertIn("recent_commits", result)
+            self.assertIn("branch_count", result)
+
+    def test_returns_git_data_for_real_repo(self):
+        # Use the orxaq-ops repo itself as test subject
+        repo = ROOT
+        result = dashboard_v2.collect_git_state(repo)
+        self.assertGreater(result["branch_count"], 0)
+        self.assertGreater(len(result["recent_commits"]), 0)
+        self.assertIn("current_branch", result)
+        # Verify commit structure
+        commit = result["recent_commits"][0]
+        self.assertIn("hash", commit)
+        self.assertIn("message", commit)
+        self.assertIn("author", commit)
+
+
+class ConnectivityTests(unittest.TestCase):
+    """Tests for collect_connectivity."""
+
+    def test_reads_connectivity_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            root.mkdir(exist_ok=True)
+            (root / "model_connectivity.json").write_text(
+                '{"endpoints": [{"id": "test", "ok": true}]}', encoding="utf-8")
+            result = dashboard_v2.collect_connectivity(root)
+            self.assertEqual(len(result["endpoints"]), 1)
+
+    def test_returns_empty_when_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_connectivity(pathlib.Path(td))
+            self.assertEqual(result, {})
+
+
+class CheckpointTests(unittest.TestCase):
+    """Tests for collect_checkpoints."""
+
+    def test_reads_checkpoint_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            cp_dir = root / "checkpoints"
+            cp_dir.mkdir(parents=True)
+            for i in range(3):
+                (cp_dir / f"cp_{i:03d}.json").write_text(
+                    json.dumps({"run_id": f"run-{i}", "cycle": i * 10}), encoding="utf-8")
+
+            result = dashboard_v2.collect_checkpoints(root)
+            self.assertEqual(len(result), 3)
+            self.assertIn("run_id", result[0])
+
+    def test_limits_to_5_most_recent(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            cp_dir = root / "checkpoints"
+            cp_dir.mkdir(parents=True)
+            for i in range(10):
+                (cp_dir / f"cp_{i:03d}.json").write_text(
+                    json.dumps({"run_id": f"run-{i}", "cycle": i}), encoding="utf-8")
+
+            result = dashboard_v2.collect_checkpoints(root)
+            self.assertEqual(len(result), 5)
+
+    def test_returns_empty_when_no_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_checkpoints(pathlib.Path(td))
+            self.assertEqual(result, [])
+
+
+class FullSnapshotTests(unittest.TestCase):
+    """Tests for the complete snapshot aggregation."""
+
+    def _build_fixture_tree(self, root):
+        """Build a realistic artifact tree for snapshot testing."""
+        auto_dir = root / "autonomy"
+        auto_dir.mkdir(parents=True)
+
+        # Health
+        (auto_dir / "health.json").write_text(
+            json.dumps({"status": "ok", "budget_daily_cap": 100, "budget_daily_spend": 5.0}),
+            encoding="utf-8")
+
+        # Global metrics
+        (auto_dir / "response_metrics_summary.json").write_text(
+            json.dumps({"responses_total": 200, "cost_usd_total": 5.0}), encoding="utf-8")
+
+        # Lanes
+        lanes_dir = auto_dir / "lanes"
+        now = datetime.now(timezone.utc)
+
+        # Active lane
+        l1 = lanes_dir / "codex-feature"
+        l1.mkdir(parents=True)
+        (l1 / "lane.json").write_text(json.dumps({"owner": "codex"}), encoding="utf-8")
+        (l1 / "state.json").write_text(json.dumps({
+            "task-1": {"status": "done", "attempts": 1, "deadlock_recoveries": 0},
+            "task-2": {"status": "in_progress", "attempts": 3, "deadlock_recoveries": 0},
+        }), encoding="utf-8")
+        (l1 / "heartbeat.json").write_text(json.dumps({
+            "cycle": 15, "phase": "execute", "pid": 100,
+            "timestamp": now.isoformat(), "message": "Working"}), encoding="utf-8")
+        (l1 / "response_metrics_summary.json").write_text(
+            json.dumps({"responses_total": 100, "cost_usd_total": 2.0, "tokens_total": 50000}),
+            encoding="utf-8")
+        (l1 / "conversations.ndjson").write_text(
+            json.dumps({"timestamp": now.isoformat(), "type": "task_done", "message": "Done"}) + "\n",
+            encoding="utf-8")
+
+        # Blocked lane
+        l2 = lanes_dir / "gemini-tests"
+        l2.mkdir(parents=True)
+        (l2 / "lane.json").write_text(json.dumps({"owner": "gemini"}), encoding="utf-8")
+        (l2 / "state.json").write_text(json.dumps({
+            "task-a": {"status": "blocked", "attempts": 5, "deadlock_recoveries": 6},
+        }), encoding="utf-8")
+        (l2 / "heartbeat.json").write_text(json.dumps({
+            "cycle": 3, "phase": "blocked", "pid": 200,
+            "timestamp": (now - timedelta(seconds=600)).isoformat(), "message": "Stuck"}),
+            encoding="utf-8")
+        (l2 / "response_metrics_summary.json").write_text(
+            json.dumps({"responses_total": 50, "cost_usd_total": 1.0, "tokens_total": 20000}),
+            encoding="utf-8")
+
+        return root
+
+    def test_snapshot_contains_all_sections(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+
+            self.assertIn("timestamp", snap)
+            self.assertIn("summary", snap)
+            self.assertIn("lanes", snap)
+            self.assertIn("health", snap)
+            self.assertIn("metrics", snap)
+            self.assertIn("events", snap)
+            self.assertIn("alerts", snap)
+            self.assertIn("git", snap)
+            self.assertIn("connectivity", snap)
+            self.assertIn("checkpoints", snap)
+
+    def test_snapshot_summary_counts(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+            s = snap["summary"]
+
+            self.assertEqual(s["lanes_total"], 2)
+            self.assertEqual(s["owner_counts"]["codex"], 1)
+            self.assertEqual(s["owner_counts"]["gemini"], 1)
+            self.assertIn("blocked", s["status_counts"])
+            self.assertGreater(s["total_cost_usd"], 0)
+            self.assertGreater(s["total_tokens"], 0)
+
+    def test_snapshot_generates_blocked_lane_alert(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+            alerts = snap["alerts"]
+
+            blocked_alerts = [a for a in alerts if a["type"] == "blocked_lane"]
+            self.assertGreater(len(blocked_alerts), 0)
+            self.assertEqual(blocked_alerts[0]["lane_id"], "gemini-tests")
+            self.assertEqual(blocked_alerts[0]["severity"], "high")
+
+    def test_snapshot_generates_stale_heartbeat_alert(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+            alerts = snap["alerts"]
+
+            stale_alerts = [a for a in alerts if a["type"] == "stale_heartbeat"]
+            self.assertGreater(len(stale_alerts), 0)
+            self.assertEqual(stale_alerts[0]["lane_id"], "gemini-tests")
+
+    def test_snapshot_generates_deadlock_storm_alert(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+            alerts = snap["alerts"]
+
+            deadlock_alerts = [a for a in alerts if a["type"] == "deadlock_storm"]
+            self.assertGreater(len(deadlock_alerts), 0)
+
+    def test_snapshot_heartbeat_age_computed(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+
+            codex_lane = next(l for l in snap["lanes"] if l["lane_id"] == "codex-feature")
+            # Fresh heartbeat should have small age
+            self.assertGreaterEqual(codex_lane["heartbeat"]["age_sec"], 0)
+            self.assertLess(codex_lane["heartbeat"]["age_sec"], 30)
+
+            gemini_lane = next(l for l in snap["lanes"] if l["lane_id"] == "gemini-tests")
+            # Stale heartbeat (600s old)
+            self.assertGreater(gemini_lane["heartbeat"]["age_sec"], 500)
+
+    def test_snapshot_with_repo_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root, repo_dir=ROOT)
+            self.assertIn("current_branch", snap["git"])
+
+    def test_snapshot_without_repo_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = self._build_fixture_tree(pathlib.Path(td))
+            snap = dashboard_v2.full_snapshot(root)
+            self.assertEqual(snap["git"], {})
+
+
+class HTTPHandlerTests(unittest.TestCase):
+    """Integration tests for the v2 HTTP handler."""
+
+    def _build_fixture_tree(self, root):
+        """Build a minimal artifact tree for HTTP tests."""
+        auto_dir = root / "autonomy"
+        auto_dir.mkdir(parents=True)
+        (auto_dir / "health.json").write_text('{"ok": true}', encoding="utf-8")
+
+        lane_dir = auto_dir / "lanes" / "test-lane"
+        lane_dir.mkdir(parents=True)
+        (lane_dir / "lane.json").write_text('{"owner": "codex"}', encoding="utf-8")
+        (lane_dir / "state.json").write_text(
+            '{"t1": {"status": "done", "attempts": 1}}', encoding="utf-8")
+        (lane_dir / "heartbeat.json").write_text(json.dumps({
+            "cycle": 5, "phase": "idle", "pid": 1,
+            "timestamp": datetime.now(timezone.utc).isoformat()}), encoding="utf-8")
+        (lane_dir / "response_metrics_summary.json").write_text(
+            '{"responses_total": 10}', encoding="utf-8")
+
+    def _start_server(self, artifacts_dir, repo_dir=None):
+        handler = dashboard_v2.make_v2_handler(artifacts_dir, repo_dir=repo_dir)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, thread
+
+    def test_root_serves_html(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/", timeout=5) as resp:
+                    body = resp.read().decode("utf-8")
+                    self.assertEqual(resp.status, 200)
+                    # Should serve the frontend HTML
+                    self.assertIn("NEXUS", body)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_v2_path_serves_html(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/v2", timeout=5) as resp:
+                    self.assertEqual(resp.status, 200)
+                    self.assertIn("NEXUS", resp.read().decode("utf-8"))
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_snapshot_returns_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/snapshot", timeout=5) as resp:
+                    self.assertEqual(resp.status, 200)
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIn("summary", data)
+                    self.assertIn("lanes", data)
+                    self.assertEqual(data["summary"]["lanes_total"], 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_lanes_returns_list(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/lanes", timeout=5) as resp:
+                    self.assertEqual(resp.status, 200)
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIsInstance(data, list)
+                    self.assertEqual(len(data), 1)
+                    self.assertEqual(data[0]["lane_id"], "test-lane")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_lanes_by_id(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/lanes/test-lane", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertEqual(data["lane_id"], "test-lane")
+                    self.assertEqual(data["owner"], "codex")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_lanes_by_id_not_found(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with self.assertRaises(urllib_error.HTTPError) as ctx:
+                    urllib_request.urlopen(f"{base}/api/v2/lanes/nonexistent", timeout=5)
+                self.assertEqual(ctx.exception.code, 404)
+                ctx.exception.close()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_events(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            # Add conversation events
+            lane_dir = root / "autonomy" / "lanes" / "test-lane"
+            (lane_dir / "conversations.ndjson").write_text(
+                json.dumps({"timestamp": "2025-01-01T00:00:00Z", "type": "task_done"}) + "\n",
+                encoding="utf-8")
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/events?tail=5", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIsInstance(data, list)
+                    self.assertEqual(len(data), 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_health(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/health", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertTrue(data["health"]["ok"])
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_metrics(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/metrics", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIn("global", data)
+                    self.assertIn("per_lane", data)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_git_with_repo(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root, repo_dir=ROOT)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/git", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIn("branches", data)
+                    self.assertGreater(data["branch_count"], 0)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_git_without_repo_returns_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root, repo_dir=None)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with self.assertRaises(urllib_error.HTTPError) as ctx:
+                    urllib_request.urlopen(f"{base}/api/v2/git", timeout=5)
+                self.assertEqual(ctx.exception.code, 400)
+                ctx.exception.close()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_unknown_route_returns_404(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with self.assertRaises(urllib_error.HTTPError) as ctx:
+                    urllib_request.urlopen(f"{base}/api/v2/nonexistent", timeout=5)
+                self.assertEqual(ctx.exception.code, 404)
+                ctx.exception.close()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_cors_header_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_fixture_tree(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/snapshot", timeout=5) as resp:
+                    cors = resp.headers.get("Access-Control-Allow-Origin")
+                    self.assertEqual(cors, "*")
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+
+class ReportTests(unittest.TestCase):
+    """Tests for collect_report."""
+
+    def test_reads_report_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            auto_dir = root / "autonomy"
+            auto_dir.mkdir(parents=True)
+            (auto_dir / "swarm_cycle_report.json").write_text(
+                json.dumps({"criteria": [{"id": "c1", "ok": True}], "summary": {}}),
+                encoding="utf-8")
+            (auto_dir / "full_autonomy_report.json").write_text(
+                json.dumps({"criteria": [{"id": "c1", "ok": True, "description": "Test"}]}),
+                encoding="utf-8")
+            result = dashboard_v2.collect_report(root)
+            self.assertIn("cycle_report", result)
+            self.assertIn("full_report", result)
+            self.assertEqual(len(result["cycle_report"]["criteria"]), 1)
+
+    def test_report_empty_when_no_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_report(pathlib.Path(td))
+            self.assertEqual(result["cycle_report"], {})
+            self.assertEqual(result["full_report"], {})
+
+
+class CostSeriesTests(unittest.TestCase):
+    """Tests for collect_cost_series."""
+
+    def test_reads_cost_data(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            cost_dir = root / "autonomy" / "provider_costs"
+            cost_dir.mkdir(parents=True)
+            (cost_dir / "summary.json").write_text(json.dumps({
+                "cost_series_hourly_24h": [{"hour": "2025-01-01T00", "cost_usd_total": 1.5}],
+                "cost_windows_usd": {"today": 5.0, "last_hour": 0.5},
+                "provider_cost_30d": {"openai": 10.0},
+                "model_cost_30d": {"gpt-4": 8.0},
+                "data_freshness": {"stale": False},
+            }), encoding="utf-8")
+            result = dashboard_v2.collect_cost_series(root)
+            self.assertEqual(len(result["hourly_series"]), 1)
+            self.assertEqual(result["windows"]["today"], 5.0)
+            self.assertEqual(result["by_provider"]["openai"], 10.0)
+
+    def test_cost_empty_when_no_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_cost_series(pathlib.Path(td))
+            self.assertEqual(result["hourly_series"], [])
+            self.assertEqual(result["windows"], {})
+
+
+class PrivilegeTests(unittest.TestCase):
+    """Tests for collect_privileges."""
+
+    def test_reads_privilege_data(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            auto_dir = root / "autonomy"
+            auto_dir.mkdir(parents=True)
+            (auto_dir / "session_autonomy_privileges.json").write_text(
+                json.dumps({"autonomy_authorized": True, "critical_security_gate": "pass"}),
+                encoding="utf-8")
+            (auto_dir / "privilege_escalations.ndjson").write_text(
+                json.dumps({"event_type": "breakglass_grant_created", "grant_id": "bg-1"}) + "\n",
+                encoding="utf-8")
+            result = dashboard_v2.collect_privileges(root)
+            self.assertTrue(result["current"]["autonomy_authorized"])
+            self.assertEqual(len(result["recent_escalations"]), 1)
+
+    def test_privileges_empty_when_no_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_privileges(pathlib.Path(td))
+            self.assertEqual(result["current"], {})
+            self.assertEqual(result["recent_escalations"], [])
+
+
+class PolicyTests(unittest.TestCase):
+    """Tests for collect_policies."""
+
+    def test_reads_policy_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            auto_dir = root / "autonomy"
+            auto_dir.mkdir(parents=True)
+            (auto_dir / "git_delivery_policy_health.json").write_text(
+                json.dumps({"violations": [], "summary": {"compliant": True}}),
+                encoding="utf-8")
+            (auto_dir / "pr_tier_policy_health.json").write_text(
+                json.dumps({"t1_ratio": 0.85}),
+                encoding="utf-8")
+            result = dashboard_v2.collect_policies(root)
+            self.assertIn("git_delivery", result["policies"])
+            self.assertIn("pr_tier", result["policies"])
+
+    def test_policies_empty_when_no_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_policies(pathlib.Path(td))
+            self.assertEqual(result["policies"], {})
+
+
+class TaskBacklogTests(unittest.TestCase):
+    """Tests for collect_task_backlog."""
+
+    def test_reads_task_backlog(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            config_dir = root.parent / "config"
+            config_dir.mkdir(parents=True, exist_ok=True)
+            tasks = [
+                {"id": "t1", "owner": "codex", "priority": 1, "title": "Task 1"},
+                {"id": "t2", "owner": "gemini", "priority": 2, "title": "Task 2"},
+                {"id": "t3", "owner": "codex", "priority": 1, "title": "Task 3"},
+            ]
+            (config_dir / "tasks.json").write_text(json.dumps(tasks), encoding="utf-8")
+            result = dashboard_v2.collect_task_backlog(root)
+            self.assertEqual(result["total"], 3)
+            self.assertEqual(result["by_owner"]["codex"], 2)
+            self.assertEqual(result["by_owner"]["gemini"], 1)
+
+    def test_backlog_empty_when_no_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            # Use a nested path so parent/config doesn't accidentally exist
+            artifacts = pathlib.Path(td) / "deep" / "nested" / "artifacts"
+            artifacts.mkdir(parents=True)
+            result = dashboard_v2.collect_task_backlog(artifacts)
+            self.assertEqual(result["total"], 0)
+            self.assertEqual(result["tasks"], [])
+
+
+class ResponseStreamTests(unittest.TestCase):
+    """Tests for collect_response_stream."""
+
+    def test_collects_response_metrics(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "lane-a"
+            lane_dir.mkdir(parents=True)
+            entries = [
+                json.dumps({"timestamp": f"2025-01-01T0{i}:00:00Z", "cost_usd": 0.01, "model": "gpt-4"})
+                for i in range(5)
+            ]
+            (lane_dir / "response_metrics.ndjson").write_text("\n".join(entries) + "\n", encoding="utf-8")
+            result = dashboard_v2.collect_response_stream(root, tail=3)
+            self.assertEqual(len(result), 3)
+            self.assertEqual(result[0]["lane_id"], "lane-a")
+
+    def test_response_stream_empty_when_no_lanes(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = dashboard_v2.collect_response_stream(pathlib.Path(td))
+            self.assertEqual(result, [])
+
+
+class NewHTTPEndpointTests(unittest.TestCase):
+    """Tests for the new enriched API HTTP endpoints."""
+
+    def _build_full_fixture(self, root):
+        """Build a fixture tree with data for all new endpoints."""
+        auto_dir = root / "autonomy"
+        auto_dir.mkdir(parents=True)
+        (auto_dir / "health.json").write_text('{"ok": true}', encoding="utf-8")
+
+        # Lane
+        lane_dir = auto_dir / "lanes" / "test-lane"
+        lane_dir.mkdir(parents=True)
+        (lane_dir / "lane.json").write_text('{"owner": "codex"}', encoding="utf-8")
+        (lane_dir / "state.json").write_text(
+            '{"t1": {"status": "done", "attempts": 1}}', encoding="utf-8")
+        (lane_dir / "heartbeat.json").write_text(json.dumps({
+            "cycle": 5, "phase": "idle", "pid": 1,
+            "timestamp": datetime.now(timezone.utc).isoformat()}), encoding="utf-8")
+        (lane_dir / "response_metrics_summary.json").write_text(
+            '{"responses_total": 10}', encoding="utf-8")
+        (lane_dir / "response_metrics.ndjson").write_text(
+            json.dumps({"timestamp": "2025-01-01T00:00:00Z", "cost_usd": 0.01}) + "\n",
+            encoding="utf-8")
+
+        # Report
+        (auto_dir / "swarm_cycle_report.json").write_text(
+            json.dumps({"criteria": [{"id": "c1", "ok": True}]}), encoding="utf-8")
+
+        # Cost series
+        cost_dir = auto_dir / "provider_costs"
+        cost_dir.mkdir(parents=True)
+        (cost_dir / "summary.json").write_text(json.dumps({
+            "cost_series_hourly_24h": [{"hour": "h1", "cost_usd_total": 1.0}],
+            "cost_windows_usd": {"today": 2.0},
+        }), encoding="utf-8")
+
+        # Privileges
+        (auto_dir / "session_autonomy_privileges.json").write_text(
+            json.dumps({"autonomy_authorized": True}), encoding="utf-8")
+
+        # Policies
+        (auto_dir / "git_delivery_policy_health.json").write_text(
+            json.dumps({"compliant": True}), encoding="utf-8")
+
+        # Task backlog
+        config_dir = root.parent / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "tasks.json").write_text(
+            json.dumps([{"id": "t1", "owner": "codex", "priority": 1}]), encoding="utf-8")
+
+    def _start_server(self, artifacts_dir):
+        handler = dashboard_v2.make_v2_handler(artifacts_dir, repo_dir=ROOT)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, thread
+
+    def test_api_report(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/report", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIn("cycle_report", data)
+                    self.assertEqual(len(data["cycle_report"]["criteria"]), 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_cost_series(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/cost-series", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertEqual(len(data["hourly_series"]), 1)
+                    self.assertEqual(data["windows"]["today"], 2.0)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_privileges(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/privileges", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertTrue(data["current"]["autonomy_authorized"])
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_policies(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/policies", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIn("git_delivery", data["policies"])
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_task_backlog(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/task-backlog", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertEqual(data["total"], 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_api_response_stream(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                with urllib_request.urlopen(f"{base}/api/v2/response-stream?tail=5", timeout=5) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    self.assertIsInstance(data, list)
+                    self.assertEqual(len(data), 1)
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+    def test_frontend_routes_serve_html(self):
+        """Test that /meridian, /prism, /signal routes return HTML content-type."""
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td) / "artifacts"
+            root.mkdir()
+            self._build_full_fixture(root)
+            server, thread = self._start_server(root)
+            try:
+                base = f"http://127.0.0.1:{server.server_port}"
+                for route in ["/meridian", "/prism", "/signal"]:
+                    try:
+                        with urllib_request.urlopen(f"{base}{route}", timeout=5) as resp:
+                            ct = resp.headers.get("Content-Type", "")
+                            self.assertIn("text/html", ct)
+                    except urllib_error.HTTPError as err:
+                        # 500 is acceptable when HTML file doesn't exist yet
+                        self.assertEqual(err.code, 500)
+                        err.close()
+            finally:
+                server.shutdown()
+                server.server_close()
+                thread.join(timeout=2)
+
+
+class EdgeCaseTests(unittest.TestCase):
+    """Tests for edge cases and robustness."""
+
+    def test_empty_artifacts_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            snap = dashboard_v2.full_snapshot(root)
+            self.assertEqual(snap["summary"]["lanes_total"], 0)
+            self.assertEqual(snap["alerts"], [])
+            self.assertEqual(snap["events"], [])
+
+    def test_lane_with_corrupt_state_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "corrupt-lane"
+            lane_dir.mkdir(parents=True)
+            (lane_dir / "state.json").write_text("NOT JSON", encoding="utf-8")
+            (lane_dir / "lane.json").write_text('{"owner": "codex"}', encoding="utf-8")
+            (lane_dir / "heartbeat.json").write_text('{}', encoding="utf-8")
+            (lane_dir / "response_metrics_summary.json").write_text('{}', encoding="utf-8")
+
+            lanes = dashboard_v2.discover_lanes(root)
+            # Should still find the lane, just with no tasks
+            self.assertEqual(len(lanes), 1)
+            self.assertEqual(lanes[0]["status"], "idle")
+
+    def test_lane_with_missing_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "bare-lane"
+            lane_dir.mkdir(parents=True)
+            # No files at all in the lane directory
+
+            lanes = dashboard_v2.discover_lanes(root)
+            self.assertEqual(len(lanes), 1)
+            self.assertEqual(lanes[0]["lane_id"], "bare-lane")
+            self.assertEqual(lanes[0]["owner"], "unknown")
+
+    def test_heartbeat_with_no_timezone_info(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "no-tz-lane"
+            lane_dir.mkdir(parents=True)
+            (lane_dir / "lane.json").write_text('{"owner": "codex"}', encoding="utf-8")
+            (lane_dir / "state.json").write_text(
+                '{"t1": {"status": "in_progress"}}', encoding="utf-8")
+            # Timestamp without timezone
+            (lane_dir / "heartbeat.json").write_text(json.dumps({
+                "timestamp": "2025-01-01T00:00:00"}), encoding="utf-8")
+            (lane_dir / "response_metrics_summary.json").write_text('{}', encoding="utf-8")
+
+            snap = dashboard_v2.full_snapshot(root)
+            lane = snap["lanes"][0]
+            # Should still compute age (assuming UTC)
+            self.assertIsNotNone(lane["heartbeat"]["age_sec"])
+
+    def test_heartbeat_with_empty_timestamp(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            lane_dir = root / "autonomy" / "lanes" / "empty-ts-lane"
+            lane_dir.mkdir(parents=True)
+            (lane_dir / "lane.json").write_text('{"owner": "codex"}', encoding="utf-8")
+            (lane_dir / "state.json").write_text('{"t1": {"status": "done"}}', encoding="utf-8")
+            (lane_dir / "heartbeat.json").write_text('{"timestamp": ""}', encoding="utf-8")
+            (lane_dir / "response_metrics_summary.json").write_text('{}', encoding="utf-8")
+
+            snap = dashboard_v2.full_snapshot(root)
+            lane = snap["lanes"][0]
+            self.assertEqual(lane["heartbeat"]["age_sec"], -1)
+
+    def test_ndjson_with_non_dict_lines(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = pathlib.Path(td) / "mixed.ndjson"
+            path.write_text('"a string"\n42\n{"ok":1}\n[1,2]\n', encoding="utf-8")
+            result = dashboard_v2._read_ndjson(path)
+            # Only the dict line should be included
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]["ok"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **Production dashboard v2** (`dashboard_v2.py`) with enriched API: lanes, health, cost series, privileges, policies, task backlog, response stream, reports, and full operator action system
- **Operator action system** (`dashboard_actions.py`) — 10 actions across 3 risk levels (low/medium/high) with two-phase confirmation, NDJSON audit logging, and rate limiting. Actions cover task management, breakglass grants, git lock healing, and runner lifecycle control
- **3 alternative frontends** each with full action UI integration:
  - **SIGNAL** — command palette / terminal aesthetic with 11 action commands
  - **MERIDIAN** — editorial briefing layout with contextual action callouts
  - **PRISM** — bento grid with glassmorphism, action tiles, and confirmation overlay
- **2 sci-fi POC dashboards** (NEXUS Canvas HUD, AEGIS React) from earlier exploration
- **139 tests** (54 action + 85 v2) all passing

## Action Taxonomy
| Risk | Actions |
|------|---------|
| LOW | `task.reprioritize`, `task.update-status`, `task.clear-error` |
| MEDIUM | `breakglass.grant`, `breakglass.revoke`, `git.heal-locks`, `runner.release-lock` |
| HIGH | `runner.stop`, `runner.start`, `runner.ensure` |

## Safety Design
- Two-phase confirmation (dry-run preview → single-use confirm token → execute) for medium/high risk
- Append-only NDJSON audit trail
- Sliding-window rate limiting (30/min global, 5/min high-risk)
- Input validation against actual state files
- Atomic file writes (tempfile + fsync + os.replace)

## Test plan
- [x] 139 unit + integration tests pass (`pytest tests/test_dashboard_actions.py tests/test_dashboard_v2.py`)
- [ ] Manual verification: start server, exercise all POST endpoints with curl dry-run
- [ ] Visual check: open all 3 frontends, verify action UI renders and executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)