### PR TITLE
feat: add hosted-controls readiness gate and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,13 @@ repos:
         pass_filenames: false
         stages: [pre-commit, pre-push]
 
+      - id: hosted-controls
+        name: hosted-controls
+        entry: python3 scripts/check_hosted_controls.py --root .
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
       - id: lint
         name: lint
         entry: make lint

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ROOT := $(CURDIR)
 export PYTHONPATH := $(ROOT)/src:$(PYTHONPATH)
 AUTONOMY := $(PYTHON) -m orxaq_autonomy.cli --root $(ROOT)
 
-.PHONY: run supervise start stop ensure status health logs reset preflight workspace open-vscode open-cursor open-pycharm install-keepalive uninstall-keepalive keepalive-status router-check router-profile-apply profile-apply rpa-schedule dashboard lint test version-check repo-hygiene pr-review-snapshot bump-patch bump-minor bump-major package setup pre-commit pre-push
+.PHONY: run supervise start stop ensure status health logs reset preflight workspace open-vscode open-cursor open-pycharm install-keepalive uninstall-keepalive keepalive-status router-check router-profile-apply profile-apply rpa-schedule dashboard lint test version-check repo-hygiene hosted-controls-check readiness-check pr-review-snapshot bump-patch bump-minor bump-major package setup pre-commit pre-push
 
 run:
 	$(AUTONOMY) run
@@ -98,6 +98,11 @@ version-check:
 
 repo-hygiene:
 	$(PYTHON) scripts/check_repo_hygiene.py --root .
+
+hosted-controls-check:
+	$(PYTHON) scripts/check_hosted_controls.py --root .
+
+readiness-check: version-check repo-hygiene hosted-controls-check preflight
 
 pr-review-snapshot:
 	$(PYTHON) scripts/pr_review_snapshot.py --root . --repo Orxaq/orxaq-ops --repo Orxaq/orxaq --output ./artifacts/autonomy/pr_review_snapshot.json --markdown ./artifacts/autonomy/pr_review_snapshot.md --json

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ make lint
 make test
 make version-check
 make repo-hygiene
+make hosted-controls-check
+make readiness-check
 make bump-patch
 make bump-minor
 make bump-major
@@ -190,6 +192,8 @@ Skill protocol + MCP context are data-driven, so you can swap project/task conte
 - Validate before push/release:
   - `make version-check`
   - `make repo-hygiene`
+  - `make hosted-controls-check`
+  - `make readiness-check`
 
 See `/Users/sdevisch/dev/orxaq-ops/docs/VERSIONING.md`.
 

--- a/docs/AI_BEST_PRACTICES.md
+++ b/docs/AI_BEST_PRACTICES.md
@@ -9,6 +9,8 @@ This repo is designed for autonomous multi-agent execution. Agents must follow t
    - `make test`
    - `make version-check`
    - `make repo-hygiene`
+   - `make hosted-controls-check`
+   - `make readiness-check`
 2. Keep changes scoped and test-backed.
 3. Do not commit generated artifacts, caches, or environment files.
 

--- a/scripts/check_hosted_controls.py
+++ b/scripts/check_hosted_controls.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate hosted controls: branch protection and README badges."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class RepoSpec:
+    repo: str
+    branch: str
+    readme: Path
+
+
+def _default_specs(root: Path) -> list[RepoSpec]:
+    return [
+        RepoSpec(repo="sdevisch/orxaq", branch="main", readme=(root.parent / "orxaq" / "README.md").resolve()),
+        RepoSpec(repo="sdevisch/orxaq-ops", branch="main", readme=(root / "README.md").resolve()),
+    ]
+
+
+def _gh_api_json(endpoint: str) -> tuple[bool, dict | None, str]:
+    proc = subprocess.run(
+        ["gh", "api", endpoint],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    raw = (proc.stdout or proc.stderr or "").strip()
+    if proc.returncode != 0:
+        return False, None, raw
+    try:
+        return True, json.loads(raw), ""
+    except Exception:
+        return False, None, f"Non-JSON response from gh api: {raw}"
+
+
+def branch_protection_errors(repo: str, branch: str) -> list[str]:
+    ok, payload, raw_error = _gh_api_json(f"repos/{repo}/branches/{branch}/protection")
+    if not ok:
+        lowered = raw_error.lower()
+        if "http 404" in lowered or "branch not protected" in lowered:
+            return [f"{repo}:{branch} is not protected."]
+        if "upgrade to github pro" in lowered:
+            return [
+                f"{repo}:{branch} protection unavailable on current GitHub plan for private repos."
+            ]
+        return [f"{repo}:{branch} protection check failed: {raw_error}"]
+
+    assert payload is not None
+    errors: list[str] = []
+    contexts = (payload.get("required_status_checks") or {}).get("contexts") or []
+    reviews = payload.get("required_pull_request_reviews") or {}
+    enforce_admins = (payload.get("enforce_admins") or {}).get("enabled") is True
+    linear = (payload.get("required_linear_history") or {}).get("enabled") is True
+    convo = (payload.get("required_conversation_resolution") or {}).get("enabled") is True
+    if not contexts:
+        errors.append(f"{repo}:{branch} has no required status checks.")
+    if not enforce_admins:
+        errors.append(f"{repo}:{branch} does not enforce protections for admins.")
+    if int(reviews.get("required_approving_review_count", 0)) < 1:
+        errors.append(f"{repo}:{branch} requires fewer than 1 approving review.")
+    if not bool(reviews.get("require_code_owner_reviews", False)):
+        errors.append(f"{repo}:{branch} does not require code owner reviews.")
+    if not linear:
+        errors.append(f"{repo}:{branch} does not require linear history.")
+    if not convo:
+        errors.append(f"{repo}:{branch} does not require conversation resolution.")
+    return errors
+
+
+def badge_urls_from_readme(readme: Path) -> list[str]:
+    text = readme.read_text(encoding="utf-8")
+    return re.findall(r"!\[[^\]]*\]\((https?://[^)]+)\)", text)
+
+
+def _badge_url_error(url: str) -> str | None:
+    req = urllib.request.Request(url, headers={"User-Agent": "orxaq-hosted-controls"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            content_type = resp.headers.get_content_type()
+            if resp.status >= 400:
+                return f"{url} returned HTTP {resp.status}"
+            if not content_type.startswith("image/"):
+                return f"{url} returned non-image content-type '{content_type}'"
+    except Exception as exc:
+        return f"{url} failed: {exc}"
+    return None
+
+
+def badge_errors(readme: Path) -> list[str]:
+    if not readme.exists():
+        return [f"Missing README for badge checks: {readme}"]
+    urls = badge_urls_from_readme(readme)
+    if not urls:
+        return [f"No badges found in {readme}"]
+    errors = [err for err in (_badge_url_error(url) for url in urls) if err]
+    return errors
+
+
+def parse_specs(root: Path, values: Iterable[str]) -> list[RepoSpec]:
+    specs: list[RepoSpec] = []
+    for value in values:
+        parts = value.split("|")
+        if len(parts) != 3:
+            raise ValueError(f"Invalid --spec '{value}'. Expected: owner/repo|branch|/abs/path/README.md")
+        repo, branch, readme = parts
+        specs.append(RepoSpec(repo=repo.strip(), branch=branch.strip(), readme=Path(readme).expanduser().resolve()))
+    return specs
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate hosted collaboration controls.")
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Path to orxaq-ops root (default: current directory).",
+    )
+    parser.add_argument(
+        "--spec",
+        action="append",
+        default=[],
+        help="Override target spec as owner/repo|branch|/abs/path/README.md (repeatable).",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    root = Path(args.root).resolve()
+    specs = parse_specs(root, args.spec) if args.spec else _default_specs(root)
+
+    all_errors: list[str] = []
+    for spec in specs:
+        all_errors.extend(branch_protection_errors(spec.repo, spec.branch))
+        all_errors.extend(badge_errors(spec.readme))
+
+    if all_errors:
+        print("Hosted controls check failed:")
+        for err in all_errors:
+            print(f"- {err}")
+        return 1
+
+    print("Hosted controls OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hosted_controls.py
+++ b/tests/test_hosted_controls.py
@@ -1,0 +1,71 @@
+import pathlib
+import tempfile
+import unittest
+import importlib.util
+import sys
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "check_hosted_controls.py"
+SPEC = importlib.util.spec_from_file_location("check_hosted_controls", MODULE_PATH)
+assert SPEC and SPEC.loader
+check_hosted_controls = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = check_hosted_controls
+SPEC.loader.exec_module(check_hosted_controls)
+
+
+class HostedControlsTests(unittest.TestCase):
+    def test_badge_urls_from_readme(self):
+        with tempfile.TemporaryDirectory() as td:
+            readme = pathlib.Path(td) / "README.md"
+            readme.write_text("[![CI](https://example.com/badge.svg)](https://example.com)\n", encoding="utf-8")
+            urls = check_hosted_controls.badge_urls_from_readme(readme)
+            self.assertEqual(urls, ["https://example.com/badge.svg"])
+
+    def test_branch_protection_errors_for_404(self):
+        with mock.patch.object(
+            check_hosted_controls,
+            "_gh_api_json",
+            return_value=(False, None, "gh: Branch not protected (HTTP 404)"),
+        ):
+            errs = check_hosted_controls.branch_protection_errors("owner/repo", "main")
+            self.assertTrue(any("not protected" in e for e in errs))
+
+    def test_branch_protection_errors_for_private_plan_403(self):
+        with mock.patch.object(
+            check_hosted_controls,
+            "_gh_api_json",
+            return_value=(False, None, "gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)"),
+        ):
+            errs = check_hosted_controls.branch_protection_errors("owner/repo", "main")
+            self.assertTrue(any("private repos" in e for e in errs))
+
+    def test_branch_protection_ok_payload(self):
+        payload = {
+            "required_status_checks": {"contexts": ["CI"]},
+            "required_pull_request_reviews": {
+                "required_approving_review_count": 1,
+                "require_code_owner_reviews": True,
+            },
+            "enforce_admins": {"enabled": True},
+            "required_linear_history": {"enabled": True},
+            "required_conversation_resolution": {"enabled": True},
+        }
+        with mock.patch.object(check_hosted_controls, "_gh_api_json", return_value=(True, payload, "")):
+            self.assertEqual(check_hosted_controls.branch_protection_errors("owner/repo", "main"), [])
+
+    def test_badge_errors_non_image(self):
+        with tempfile.TemporaryDirectory() as td:
+            readme = pathlib.Path(td) / "README.md"
+            readme.write_text("[![CI](https://example.com/badge.svg)](https://example.com)\n", encoding="utf-8")
+            with mock.patch.object(
+                check_hosted_controls,
+                "_badge_url_error",
+                return_value="https://example.com/badge.svg returned non-image content-type 'text/html'",
+            ):
+                errs = check_hosted_controls.badge_errors(readme)
+                self.assertEqual(len(errs), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `check_hosted_controls.py` readiness gate script
- Add `readiness-check` Makefile target that chains version-check, repo-hygiene, hosted-controls-check, and preflight
- Add comprehensive tests for hosted controls validation
- Resolve Makefile merge with upstream (integrate router, dashboard, and pr-review-snapshot targets)

## Test plan
- [ ] Run `make readiness-check` and verify all gates pass
- [ ] Run `make hosted-controls-check` in isolation
- [ ] Run `make test` to verify all 90 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)